### PR TITLE
Add support for delayed jobs if the Publisher supports the feature

### DIFF
--- a/lib/chore/job.rb
+++ b/lib/chore/job.rb
@@ -122,7 +122,7 @@ module Chore
     # the given publisher does not support delayed jobs a warning should be issued and the job will be queued without a
     # delay.
     def perform_delayed(delay, *args)
-      push_to_publisher(args, delay: delay)
+      push_to_publisher(args, :delay => delay)
     end
 
     private

--- a/lib/chore/publisher.rb
+++ b/lib/chore/publisher.rb
@@ -11,12 +11,12 @@ module Chore
 
     # Publishes the provided +job+ to the queue identified by the +queue_name+. Not designed to be used directly, this
     # method ferries to the publish method on an instance of your configured Publisher.
-    def self.publish(queue_name,job)
-      self.new.publish(queue_name,job)
+    def self.publish(queue_name, job, options={})
+      self.new.publish(queue_name, job, options)
     end
 
     # Raises a NotImplementedError. This method should be overridden in your descendent, custom publisher class
-    def publish(queue_name,job)
+    def publish(queue_name, job, options={})
       raise NotImplementedError
     end
   protected

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -14,8 +14,12 @@ module Chore
         FILE_MUTEX = Mutex.new
 
         # use of mutex and file locking should make this both threadsafe and safe for multiple
-        # processes to use the same queue directory simultaneously. 
-        def publish(queue_name,job)
+        # processes to use the same queue directory simultaneously.
+        def publish(queue_name ,job, options={})
+          if options[:delay]
+            Chore.logger.warn("The Filesystem queue does not support delayed publishing! Ignoring this option.")
+          end
+
           FILE_MUTEX.synchronize do
             while true
               # keep trying to get a file with nothing in it meaning we just created it

--- a/spec/chore/job_spec.rb
+++ b/spec/chore/job_spec.rb
@@ -38,11 +38,14 @@ describe Chore::Job do
     TestJob.options[:name].should == 'test_queue'
   end
 
-  describe(:perform_async) do 
+  describe(:perform_async) do
     it 'should call an instance of the queue_options publisher' do
       args = [1,2,{:h => 'ash'}]
       TestJob.queue_options(:publisher => Chore::Publisher)
-      Chore::Publisher.any_instance.should_receive(:publish).with('test_queue',{:class => 'TestJob',:args => args}).and_return(true)
+      Chore::Publisher.any_instance.should_receive(:publish).with(
+        'test_queue',
+        {:class => 'TestJob', :args => args},
+        {}).and_return(true)
       TestJob.perform_async(*args)
     end
   end

--- a/spec/chore/queues/sqs/publisher_spec.rb
+++ b/spec/chore/queues/sqs/publisher_spec.rb
@@ -35,13 +35,13 @@ module Chore
     end
 
     it 'supports SQS delayed messages feature' do
-      queue.should_receive(:send_message).with(job.to_json, {delay_seconds: 300})
-      publisher.publish(queue_name, job, delay: 300)
+      queue.should_receive(:send_message).with(job.to_json, {:delay_seconds => 300})
+      publisher.publish(queue_name, job, :delay => 300)
     end
 
     it 'forces the maximum SQS delay of 900 seconds' do
-      queue.should_receive(:send_message).with(job.to_json, {delay_seconds: 900})
-      publisher.publish(queue_name, job, delay: 1200)
+      queue.should_receive(:send_message).with(job.to_json, {:delay_seconds => 900})
+      publisher.publish(queue_name, job, :delay => 1200)
     end
 
     it 'should lookup the queue when publishing' do


### PR DESCRIPTION
SQS has a `DelaySeconds` attribute for individual messages allow you to immediately mark a message as invisible for that amount of time. We need this functionality for [TPAT work with Google](https://jira.tapjoy.net/browse/DMMEAS-17). We can also use this to exponentially (up to a limit) back off retries for the (eg) Downloads queue!

If a Publisher doesn't support a delay we're currently warning to the `Chore.logger` and ignoring the setting. In the case of SQS, which has a maximum delay of 900 seconds, we warn if the given delay is greater than the maximum and log a warning.

/to @StabbyCutyou 
/cc @jjrussell, @andyleclair, @nwmartin 