### PR TITLE
Only log to SQS at the same level as Chore

### DIFF
--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -118,7 +118,7 @@ module Chore
             :access_key_id => Chore.config.aws_access_key,
             :secret_access_key => Chore.config.aws_secret_key,
             :logger => Chore.logger,
-            :log_level => :debug)
+            :log_level => Chore.config.log_level)
         end
 
         def sqs_polling_amount

--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -114,11 +114,12 @@ module Chore
 
         # Access to the configured SQS connection object
         def sqs
-          @sqs ||= AWS::SQS.new(
+          sqs_options = {
             :access_key_id => Chore.config.aws_access_key,
-            :secret_access_key => Chore.config.aws_secret_key,
-            :logger => Chore.logger,
-            :log_level => Chore.config.log_level)
+            :secret_access_key => Chore.config.aws_secret_key
+          }
+          sqs_options.merge!(:logger => Chore.logger, :log_level => :debug) if Chore.config.log_level == Logger::DEBUG
+          @sqs ||= AWS::SQS.new(sqs_options)
         end
 
         def sqs_polling_amount

--- a/spec/chore/queues/sqs/consumer_spec.rb
+++ b/spec/chore/queues/sqs/consumer_spec.rb
@@ -34,9 +34,7 @@ describe Chore::Queues::SQS::Consumer do
 
       expect(AWS::SQS).to receive(:new).with(
         :access_key_id => 'key',
-        :secret_access_key => 'secret',
-        :logger => Chore.logger,
-        :log_level => :debug
+        :secret_access_key => 'secret'
       ).and_return(sqs)
       consumer.consume
     end
@@ -141,6 +139,28 @@ describe Chore::Queues::SQS::Consumer do
       allow(AWS::SQS).to receive(:new).and_return(sqs)
 
       expect(consumer).to receive(:running?).and_return(true, false)
+      consumer.consume
+    end
+  end
+
+  describe 'aws logging' do
+    it 'should not set AWS logging if Chore log level is info' do
+      allow(Chore.config).to receive(:log_level).and_return(Logger::INFO)
+
+      allow(consumer).to receive(:running?).and_return(true, false)
+      allow(queue).to receive(:receive_messages).and_return(message)
+
+      expect(AWS::SQS).to receive(:new).with(hash_not_including(:logger => Chore.logger, :log_level => :debug))
+      consumer.consume
+    end
+
+    it 'should set the AWS logging if Chore log level is debug' do
+      allow(Chore.config).to receive(:log_level).and_return(Logger::DEBUG)
+
+      allow(consumer).to receive(:running?).and_return(true, false)
+      allow(queue).to receive(:receive_messages).and_return(message)
+
+      expect(AWS::SQS).to receive(:new).with(hash_including(:logger => Chore.logger, :log_level => :debug))
       consumer.consume
     end
   end


### PR DESCRIPTION
This creates real problems when relying on STDOUT and piping for log handling. There's literally no way to stop AWS from spamming your log with messaging without something like this.

ping @StabbyCutyou 