### PR TITLE
First pass at doing a batched-worker mode (different from the batcher…

### DIFF
--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -141,6 +141,7 @@ module Chore #:nodoc:
 
       register_option 'dupe_on_cache_failure', '--dupe-on-cache-failure BOOLEAN', 'Determines the deduping behavior when a cache connection error occurs. When set to false, the message is assumed not to be a duplicate. (default: false)'
 
+      register_option 'process_in_batches', '--process-in-batches BOOLEAN', 'Determines if the Worker should hand each message to a single instance of a Job, or if the Jobs are intended to make multiple messages and work over all of them. (default: false)'
     end
 
     def parse_opts(argv) #:nodoc:
@@ -249,4 +250,3 @@ module Chore #:nodoc:
     end
   end
 end
-

--- a/lib/chore/manager.rb
+++ b/lib/chore/manager.rb
@@ -10,7 +10,10 @@ module Chore
       Chore.logger.info "Booting Chore #{Chore::VERSION}"
       Chore.logger.debug { Chore.config.inspect }
       @started_at = nil
-      @worker_strategy = Chore.config.worker_strategy.new(self)
+      worker_opts = {
+        :process_in_batches=>Chore.config.process_in_batches
+      }
+      @worker_strategy = Chore.config.worker_strategy.new(self, worker_opts)
       @fetcher = Chore.config.fetcher.new(self)
       @processed = 0
       @stopping = false

--- a/lib/chore/unit_of_work.rb
+++ b/lib/chore/unit_of_work.rb
@@ -8,7 +8,7 @@ module Chore
   # * +:previous_attempts+ The number of times the work has been attempted previously.
   # * +:consumer+ The consumer instance used to fetch this message. Most queue implementations won't need access to this, but some (RabbitMQ) will. So we
   # make sure to pass it along with each message. This instance will be used by the Worker for things like <tt>complete</tt> and </tt>reject</tt>.
-  class UnitOfWork < Struct.new(:id,:queue_name,:queue_timeout,:message,:previous_attempts,:consumer)
+  class UnitOfWork < Struct.new(:id,:queue_name,:queue_timeout,:message,:previous_attempts,:consumer,:decoded_message, :klass)
     # The current attempt number for the worker processing this message.
     def current_attempt
       previous_attempts + 1

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -28,7 +28,10 @@ module Chore
       @started_at = Time.now
       @work = work
       @work = [work] unless work.kind_of?(Array)
-      self.options = {:payload_handler => Chore.config.payload_handler}.merge(opts)
+      self.options = {
+        :payload_handler => Chore.config.payload_handler,
+        :process_in_batches => false
+      }.merge(opts)
     end
 
     # Whether this worker has existed for longer than it's allowed to
@@ -53,9 +56,21 @@ module Chore
     #   the permanent failure hooks and Consumer#complete.
     # * Log the results via the Chore.logger
     def start
+      if self.options[:process_in_batches] == true
+        start_work_in_batches
+      else
+        start_work
+      end
+    end
+
+    # This method will perform the traditional behavior of doing the work one by one
+    # A single message will be handed to a single job class for processing.
+    def start_work
       @work.each do |item|
         return if @stopping
         begin
+          item.decoded_message = options[:payload_handler].decode(item.message)
+          item.klass = options[:payload_handler].payload_class(item.decoded_message)
           start_item(item)
         rescue => e
           Chore.logger.error { "Failed to run job for #{item.message} with error: #{e.message} #{e.backtrace * "\n"}" }
@@ -69,6 +84,35 @@ module Chore
       end
     end
 
+    # This method will perform a batching operation, where all the messages for a given
+    # job class will be grouped together by that class, and handed to it in a single batch.
+    # This is a special use case, only to be used when the performance benefits of
+    # running multiple jobs as one makes sense.
+    def start_work_in_batches
+      # First, we need to deserialize the message payloads
+      @work.each {|item| item.decoded_message = options[:payload_handler].decode(item.message)}
+      # Now, because a single queue could theoretically contain different job payloads,
+      # we need to group the results by job type
+      work_groups = @work.group_by {|item| item.klass = options[:payload_handler].payload_class(item.decoded_message)}
+      # We now have a hash of JobClass => Array of payloads to run
+      work_groups.each do |klass, items|
+        return if @stopping
+        begin
+          start_batched_items(klass, items)
+        rescue => e
+          Chore.logger.error { "Failed to run batched-jobs for #{items.map(&:message).join("\n")} with error: #{e.message} #{e.backtrace * "\n"}" }
+          items.each do |item|
+            if item.current_attempt >= Chore.config.max_attempts
+              Chore.run_hooks_for(:on_permanent_failure,item.queue_name,item.message,e)
+              item.consumer.complete(item.id)
+            else
+              Chore.run_hooks_for(:on_failure,item.message,e)
+            end
+          end
+        end
+      end
+    end
+
     # Tell the worker to stop after it completes the current job.
     def stop!
       @stopping = true
@@ -76,9 +120,9 @@ module Chore
 
   private
     def start_item(item)
-      message = options[:payload_handler].decode(item.message)
-      klass = options[:payload_handler].payload_class(message)
-      return unless klass.run_hooks_for(:before_perform,message)
+      klass = item.klass
+      message = item.decoded_message
+      return unless klass.run_hooks_for(:before_perform, message)
 
       begin
         Chore.logger.info { "Running job #{klass} with params #{message}"}
@@ -95,6 +139,34 @@ module Chore
           attempt_to_delay(item, message, klass)
         else
           handle_failure(item, message, klass, e)
+        end
+      end
+    end
+
+    def start_batched_items(klass, items)
+      items.each {|item| return unless item.klass.run_hooks_for(:before_perform,item.message)}
+      logged_batch_payload = items.map(&:message).join("\n")
+      begin
+        Chore.logger.info { "Running job #{klass} with params #{logged_batch_payload}"}
+        perform_batch_job(klass,items.map(&:decoded_message))
+        items.each do |item|
+          item.consumer.complete(item.id)
+          klass.run_hooks_for(:after_perform, item.decoded_message)
+        end
+        Chore.logger.info { "Finished job #{klass} with params #{logged_batch_payload}"}
+      rescue Job::RejectMessageException
+        Chore.logger.error { "Failed to run job for #{logged_batch_payload}  with error: Job raised a RejectMessageException" }
+        items.each do |item|
+          item.consumer.reject(item.id)
+          klass.run_hooks_for(:on_rejected, item.decoded_message)
+        end
+      rescue => e
+        items.each do |item|
+          if klass.has_backoff?
+            attempt_to_delay(item, item.decoded_message, klass)
+          else
+            handle_failure(item, item.decoded_message, klass, e)
+          end
         end
       end
     end
@@ -119,6 +191,10 @@ module Chore
 
     def perform_job(klass, message)
       klass.perform(*options[:payload_handler].payload(message))
+    end
+
+    def perform_batch_job(klass, messages)
+      klass.perform(messages.map {|m|options[:payload_handler].payload(m)})
     end
   end
 end


### PR DESCRIPTION
…) to coalesce multiple jobs into one for certain performance edgecases

ping @theo-lanman @Tapjoy/eng-group-services 

So, I took a stab at this. There is probably a little cleanup I code do, but I wanted to be as minimally invasive as possible, as Chore really isn't set up internally to make this kind of thing efficient - lots of stuff assumes one and only one message at a time (like the hooks, for example).

Theres lots we could do to improve that, but it's both outside the scope of this work, and not really the performance bottleneck we're aiming to solve (which is network latency in a very specific, high throughput job).

I looked at moving this behavior to the publisher / consumer to keep the worker agnostic, but the system just isn't designed for it overall, and we'd have a lot more to update. I can go over them in person better than explaining them here, but the gist is: Multiple processes writing to the same file where the data is likely above the linux limit on safe writes without interleaving data, the serialized job data would not be in a convenient format to match the downstream worker model, and it would have overall been more code to accomplish the same thing in what ended up looking like a more brittle approach.

It's a great use case to keep in mind if we get around to a proper design session on Chore 2.0.

Thoughts on this? Not yet tested, going to work on that shortly.