### PR TITLE
Only explicitly use Bundler.require when in non-rails environments

### DIFF
--- a/bin/chore
+++ b/bin/chore
@@ -22,9 +22,6 @@ Chore::Signal.trap "USR1" do
 end
 
 begin
-  # Pre-load any Bundler dependencies now, so that the CLI parser has them loaded
-  # prior to intrpretting the command line args for things like consumers/producers
-  Bundler.require if defined?(Bundler)
   cli = Chore::CLI.instance
   cli.run!(ARGV)
 rescue => e


### PR DESCRIPTION
This is a regression introduced by https://github.com/Tapjoy/chore/issues/5.  Invoking `Bundler.require` within a Rails app *prior* to actually loading the rails libraries causes issues.  In particular:
* There are some gems that simply assume that Rails has been loaded (rather than require dependencies)
* More importantly, Railtie files typically only get loaded by gems when they detect that Rails is available (via something like `defined?(Rails)`).

By requiring all gems ahead of time, we break the above two assumptions since there's no guarantee on when Rails actually gets loaded.  We could explicitly define the `require` option for every gem, but that's going to be full of headaches.

Instead, this makes that behavior part of Chore's bootup process.  The primary reason for having this at all is so that 3rd-party chore gems can introduce additional cli options.  Since chore processes the cli options twice (once before boot and once after boot), this still works.

/to @StabbyCutyou 
/cc @Tapjoy/eng-group-services 