### PR TITLE
Add profiler

### DIFF
--- a/bin/chore
+++ b/bin/chore
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'ruby-prof'
+RubyProf.start
 require 'chore'
 require 'chore/cli'
 require 'chore/signal'
@@ -13,6 +15,11 @@ require 'resolv-replace'
 
 ["INT","TERM","QUIT"].each do |sig|
   Chore::Signal.trap sig do
+    result = RubyProf.stop
+    printer = RubyProf::CallStackPrinter.new(result)
+    File.open('./profile_out.html', 'w') do |file|
+      printer.print(file, {})
+    end
     Chore::CLI.instance.shutdown
   end
 end

--- a/chore-core.gemspec
+++ b/chore-core.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<json>, [">= 0"])
   s.add_runtime_dependency(%q<aws-sdk-v1>, ["~> 1.56", ">= 1.56.0"])
   s.add_runtime_dependency(%q<thread>, ["~> 0.1.3"])
+  s.add_runtime_dependency(%q<ruby-prof>, ["= 0.15.9"])
   s.add_development_dependency(%q<rspec>, ["~> 3.3.0"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
   s.add_development_dependency(%q<bundler>, [">= 0"])

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -4,6 +4,6 @@ module Chore
     MINOR = 8
     PATCH = 0
 
-    STRING = [ MAJOR, MINOR, PATCH ].join('.')
+    STRING = [ MAJOR, MINOR, PATCH ].join('.') + '-profiling'
   end
 end


### PR DESCRIPTION
@Tapjoy/eng-group-services 

__DO NOT MERGE__

Here's the profiling code for Chore.

This includes a pre-release version tag. This will evaluate as an "earlier" version than 1.8.0, so this should be safe to build as a gem.

Does this look safe to build and run in production?