### PR TITLE
WIP: batched jobs with subclassed worker

### DIFF
--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -13,6 +13,7 @@ require 'chore/manager'
 require 'chore/publisher'
 require 'chore/util'
 require 'chore/worker'
+require 'chore/batched_worker'
 require 'chore/publisher'
 
 # We have a number of things that can live here. I don't want to track

--- a/lib/chore/batched_worker.rb
+++ b/lib/chore/batched_worker.rb
@@ -1,0 +1,64 @@
+module Chore
+  class BatchedWorker < Worker
+    # This method will perform a batching operation, where all the messages for a given
+    # job class will be grouped together by that class, and handed to it in a single batch.
+    # This is a special use case, only to be used when the performance benefits of
+    # running multiple jobs as one makes sense.
+    def start
+      # First, we need to deserialize the message payloads
+      @work.each {|item| item.decoded_message = options[:payload_handler].decode(item.message)}
+      # Now, because a single queue could theoretically contain different job payloads,
+      # we need to group the results by job type
+      work_groups = @work.group_by {|item| item.klass = options[:payload_handler].payload_class(item.decoded_message)}
+      # We now have a hash of JobClass => Array of payloads to run
+      work_groups.each do |klass, items|
+        return if @stopping
+        begin
+          start_batched_items(klass, items)
+        rescue => e
+          Chore.logger.error { "Failed to run batched-jobs for #{items.map(&:message).join("\n")} with error: #{e.message} #{e.backtrace * "\n"}" }
+          items.each do |item|
+            if item.current_attempt >= Chore.config.max_attempts
+              Chore.run_hooks_for(:on_permanent_failure,item.queue_name,item.message,e)
+              item.consumer.complete(item.id)
+            else
+              Chore.run_hooks_for(:on_failure,item.message,e)
+            end
+          end
+        end
+      end
+    end
+
+    def start_batched_items(klass, items)
+      items.each {|item| return unless item.klass.run_hooks_for(:before_perform,item.message)}
+      logged_batch_payload = items.map(&:message).join("\n")
+      begin
+        Chore.logger.info { "Running job #{klass} with params #{logged_batch_payload}"}
+        perform_batch_job(klass,items.map(&:decoded_message))
+        items.each do |item|
+          item.consumer.complete(item.id)
+          klass.run_hooks_for(:after_perform, item.decoded_message)
+        end
+        Chore.logger.info { "Finished job #{klass} with params #{logged_batch_payload}"}
+      rescue Job::RejectMessageException
+        Chore.logger.error { "Failed to run job for #{logged_batch_payload}  with error: Job raised a RejectMessageException" }
+        items.each do |item|
+          item.consumer.reject(item.id)
+          klass.run_hooks_for(:on_rejected, item.decoded_message)
+        end
+      rescue => e
+        items.each do |item|
+          if klass.has_backoff?
+            attempt_to_delay(item, item.decoded_message, klass)
+          else
+            handle_failure(item, item.decoded_message, klass, e)
+          end
+        end
+      end
+    end
+
+    def perform_batch_job(klass, messages)
+      klass.perform_batch(messages.flat_map {|m|options[:payload_handler].payload(m)})
+    end
+  end
+end

--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -144,6 +144,7 @@ module Chore #:nodoc:
 
       register_option 'dupe_on_cache_failure', '--dupe-on-cache-failure BOOLEAN', 'Determines the deduping behavior when a cache connection error occurs. When set to false, the message is assumed not to be a duplicate. (default: false)'
 
+      register_option 'process_in_batches', '--process-in-batches BOOLEAN', 'Determines if the Worker should hand each message to a single instance of a Job, or if the Jobs are intended to make multiple messages and work over all of them. (default: false)'
     end
 
     def parse_opts(argv, ignore_errors = false) #:nodoc:
@@ -270,4 +271,3 @@ module Chore #:nodoc:
     end
   end
 end
-

--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -144,7 +144,6 @@ module Chore #:nodoc:
 
       register_option 'dupe_on_cache_failure', '--dupe-on-cache-failure BOOLEAN', 'Determines the deduping behavior when a cache connection error occurs. When set to false, the message is assumed not to be a duplicate. (default: false)'
 
-      register_option 'process_in_batches', '--process-in-batches BOOLEAN', 'Determines if the Worker should hand each message to a single instance of a Job, or if the Jobs are intended to make multiple messages and work over all of them. (default: false)'
     end
 
     def parse_opts(argv, ignore_errors = false) #:nodoc:

--- a/lib/chore/job.rb
+++ b/lib/chore/job.rb
@@ -85,6 +85,12 @@ module Chore
         job.perform(*args)
       end
 
+      # Execute the current job in batch mode. This is only used with a batching worker strategy.
+      def perform_batch(*args)
+        job = self.new(args)
+        job.perform_batch(*args)
+      end
+
       # Publish a job using an instance of job. Similar to perform we do this so that a job
       # can perform initialization logic before the perform_async is begun. This, in addition, to
       # hooks allows for rather complex jobs to be written simply.
@@ -118,6 +124,10 @@ module Chore
 
     # This needs to be overriden by the object that is including this module.
     def perform(*args)
+      raise NotImplementedError
+    end
+
+    def perform_batch(*args)
       raise NotImplementedError
     end
 

--- a/lib/chore/manager.rb
+++ b/lib/chore/manager.rb
@@ -10,10 +10,7 @@ module Chore
       Chore.logger.info "Booting Chore #{Chore::VERSION}"
       Chore.logger.debug { Chore.config.inspect }
       @started_at = nil
-      worker_opts = {
-        :process_in_batches=>Chore.config.process_in_batches
-      }
-      @worker_strategy = Chore.config.worker_strategy.new(self, worker_opts)
+      @worker_strategy = Chore.config.worker_strategy.new(self)
       @fetcher = Chore.config.fetcher.new(self)
       @processed = 0
       @stopping = false

--- a/lib/chore/manager.rb
+++ b/lib/chore/manager.rb
@@ -10,7 +10,10 @@ module Chore
       Chore.logger.info "Booting Chore #{Chore::VERSION}"
       Chore.logger.debug { Chore.config.inspect }
       @started_at = nil
-      @worker_strategy = Chore.config.worker_strategy.new(self)
+      worker_opts = {
+        :process_in_batches=>Chore.config.process_in_batches
+      }
+      @worker_strategy = Chore.config.worker_strategy.new(self, worker_opts)
       @fetcher = Chore.config.fetcher.new(self)
       @processed = 0
       @stopping = false

--- a/lib/chore/strategies/worker/single_batched_worker_strategy.rb
+++ b/lib/chore/strategies/worker/single_batched_worker_strategy.rb
@@ -1,0 +1,16 @@
+require 'chore/strategies/worker/single_worker_strategy'
+
+module Chore
+  module Strategy
+    class SingleBatchedWorkerStrategy < SingleWorkerStrategy
+      def assign(work)
+        if workers_available?
+          @worker = BatchedWorker.new(work, @options)
+          @worker.start
+          @worker = nil
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/chore/unit_of_work.rb
+++ b/lib/chore/unit_of_work.rb
@@ -8,7 +8,7 @@ module Chore
   # * +:previous_attempts+ The number of times the work has been attempted previously.
   # * +:consumer+ The consumer instance used to fetch this message. Most queue implementations won't need access to this, but some (RabbitMQ) will. So we
   # make sure to pass it along with each message. This instance will be used by the Worker for things like <tt>complete</tt> and </tt>reject</tt>.
-  class UnitOfWork < Struct.new(:id,:queue_name,:queue_timeout,:message,:previous_attempts,:consumer)
+  class UnitOfWork < Struct.new(:id,:queue_name,:queue_timeout,:message,:previous_attempts,:consumer,:decoded_message, :klass)
     # The current attempt number for the worker processing this message.
     def current_attempt
       previous_attempts + 1

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -28,10 +28,7 @@ module Chore
       @started_at = Time.now
       @work = work
       @work = [work] unless work.kind_of?(Array)
-      self.options = {
-        :payload_handler => Chore.config.payload_handler,
-        :process_in_batches => false
-      }.merge(opts)
+      self.options = {:payload_handler => Chore.config.payload_handler}.merge(opts)
     end
 
     # Whether this worker has existed for longer than it's allowed to
@@ -56,16 +53,6 @@ module Chore
     #   the permanent failure hooks and Consumer#complete.
     # * Log the results via the Chore.logger
     def start
-      if self.options[:process_in_batches] == true
-        start_work_in_batches
-      else
-        start_work
-      end
-    end
-
-    # This method will perform the traditional behavior of doing the work one by one
-    # A single message will be handed to a single job class for processing.
-    def start_work
       @work.each do |item|
         return if @stopping
         begin
@@ -79,35 +66,6 @@ module Chore
             item.consumer.complete(item.id)
           else
             Chore.run_hooks_for(:on_failure,item.message,e)
-          end
-        end
-      end
-    end
-
-    # This method will perform a batching operation, where all the messages for a given
-    # job class will be grouped together by that class, and handed to it in a single batch.
-    # This is a special use case, only to be used when the performance benefits of
-    # running multiple jobs as one makes sense.
-    def start_work_in_batches
-      # First, we need to deserialize the message payloads
-      @work.each {|item| item.decoded_message = options[:payload_handler].decode(item.message)}
-      # Now, because a single queue could theoretically contain different job payloads,
-      # we need to group the results by job type
-      work_groups = @work.group_by {|item| item.klass = options[:payload_handler].payload_class(item.decoded_message)}
-      # We now have a hash of JobClass => Array of payloads to run
-      work_groups.each do |klass, items|
-        return if @stopping
-        begin
-          start_batched_items(klass, items)
-        rescue => e
-          Chore.logger.error { "Failed to run batched-jobs for #{items.map(&:message).join("\n")} with error: #{e.message} #{e.backtrace * "\n"}" }
-          items.each do |item|
-            if item.current_attempt >= Chore.config.max_attempts
-              Chore.run_hooks_for(:on_permanent_failure,item.queue_name,item.message,e)
-              item.consumer.complete(item.id)
-            else
-              Chore.run_hooks_for(:on_failure,item.message,e)
-            end
           end
         end
       end
@@ -143,34 +101,6 @@ module Chore
       end
     end
 
-    def start_batched_items(klass, items)
-      items.each {|item| return unless item.klass.run_hooks_for(:before_perform,item.message)}
-      logged_batch_payload = items.map(&:message).join("\n")
-      begin
-        Chore.logger.info { "Running job #{klass} with params #{logged_batch_payload}"}
-        perform_batch_job(klass,items.map(&:decoded_message))
-        items.each do |item|
-          item.consumer.complete(item.id)
-          klass.run_hooks_for(:after_perform, item.decoded_message)
-        end
-        Chore.logger.info { "Finished job #{klass} with params #{logged_batch_payload}"}
-      rescue Job::RejectMessageException
-        Chore.logger.error { "Failed to run job for #{logged_batch_payload}  with error: Job raised a RejectMessageException" }
-        items.each do |item|
-          item.consumer.reject(item.id)
-          klass.run_hooks_for(:on_rejected, item.decoded_message)
-        end
-      rescue => e
-        items.each do |item|
-          if klass.has_backoff?
-            attempt_to_delay(item, item.decoded_message, klass)
-          else
-            handle_failure(item, item.decoded_message, klass, e)
-          end
-        end
-      end
-    end
-
     def attempt_to_delay(item, message, klass)
       delayed_for = item.consumer.delay(item, klass.options[:backoff])
       Chore.logger.info { "Delaying retry by #{delayed_for} seconds for the job #{item.message}" }
@@ -191,10 +121,6 @@ module Chore
 
     def perform_job(klass, message)
       klass.perform(*options[:payload_handler].payload(message))
-    end
-
-    def perform_batch_job(klass, messages)
-      klass.perform(messages.flat_map {|m|options[:payload_handler].payload(m)})
     end
   end
 end

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -28,7 +28,10 @@ module Chore
       @started_at = Time.now
       @work = work
       @work = [work] unless work.kind_of?(Array)
-      self.options = {:payload_handler => Chore.config.payload_handler}.merge(opts)
+      self.options = {
+        :payload_handler => Chore.config.payload_handler,
+        :process_in_batches => false
+      }.merge(opts)
     end
 
     # Whether this worker has existed for longer than it's allowed to
@@ -53,9 +56,21 @@ module Chore
     #   the permanent failure hooks and Consumer#complete.
     # * Log the results via the Chore.logger
     def start
+      if self.options[:process_in_batches] == true
+        start_work_in_batches
+      else
+        start_work
+      end
+    end
+
+    # This method will perform the traditional behavior of doing the work one by one
+    # A single message will be handed to a single job class for processing.
+    def start_work
       @work.each do |item|
         return if @stopping
         begin
+          item.decoded_message = options[:payload_handler].decode(item.message)
+          item.klass = options[:payload_handler].payload_class(item.decoded_message)
           start_item(item)
         rescue => e
           Chore.logger.error { "Failed to run job for #{item.message} with error: #{e.message} #{e.backtrace * "\n"}" }
@@ -69,6 +84,35 @@ module Chore
       end
     end
 
+    # This method will perform a batching operation, where all the messages for a given
+    # job class will be grouped together by that class, and handed to it in a single batch.
+    # This is a special use case, only to be used when the performance benefits of
+    # running multiple jobs as one makes sense.
+    def start_work_in_batches
+      # First, we need to deserialize the message payloads
+      @work.each {|item| item.decoded_message = options[:payload_handler].decode(item.message)}
+      # Now, because a single queue could theoretically contain different job payloads,
+      # we need to group the results by job type
+      work_groups = @work.group_by {|item| item.klass = options[:payload_handler].payload_class(item.decoded_message)}
+      # We now have a hash of JobClass => Array of payloads to run
+      work_groups.each do |klass, items|
+        return if @stopping
+        begin
+          start_batched_items(klass, items)
+        rescue => e
+          Chore.logger.error { "Failed to run batched-jobs for #{items.map(&:message).join("\n")} with error: #{e.message} #{e.backtrace * "\n"}" }
+          items.each do |item|
+            if item.current_attempt >= Chore.config.max_attempts
+              Chore.run_hooks_for(:on_permanent_failure,item.queue_name,item.message,e)
+              item.consumer.complete(item.id)
+            else
+              Chore.run_hooks_for(:on_failure,item.message,e)
+            end
+          end
+        end
+      end
+    end
+
     # Tell the worker to stop after it completes the current job.
     def stop!
       @stopping = true
@@ -76,9 +120,9 @@ module Chore
 
   private
     def start_item(item)
-      message = options[:payload_handler].decode(item.message)
-      klass = options[:payload_handler].payload_class(message)
-      return unless klass.run_hooks_for(:before_perform,message)
+      klass = item.klass
+      message = item.decoded_message
+      return unless klass.run_hooks_for(:before_perform, message)
 
       begin
         Chore.logger.info { "Running job #{klass} with params #{message}"}
@@ -95,6 +139,34 @@ module Chore
           attempt_to_delay(item, message, klass)
         else
           handle_failure(item, message, klass, e)
+        end
+      end
+    end
+
+    def start_batched_items(klass, items)
+      items.each {|item| return unless item.klass.run_hooks_for(:before_perform,item.message)}
+      logged_batch_payload = items.map(&:message).join("\n")
+      begin
+        Chore.logger.info { "Running job #{klass} with params #{logged_batch_payload}"}
+        perform_batch_job(klass,items.map(&:decoded_message))
+        items.each do |item|
+          item.consumer.complete(item.id)
+          klass.run_hooks_for(:after_perform, item.decoded_message)
+        end
+        Chore.logger.info { "Finished job #{klass} with params #{logged_batch_payload}"}
+      rescue Job::RejectMessageException
+        Chore.logger.error { "Failed to run job for #{logged_batch_payload}  with error: Job raised a RejectMessageException" }
+        items.each do |item|
+          item.consumer.reject(item.id)
+          klass.run_hooks_for(:on_rejected, item.decoded_message)
+        end
+      rescue => e
+        items.each do |item|
+          if klass.has_backoff?
+            attempt_to_delay(item, item.decoded_message, klass)
+          else
+            handle_failure(item, item.decoded_message, klass, e)
+          end
         end
       end
     end
@@ -119,6 +191,10 @@ module Chore
 
     def perform_job(klass, message)
       klass.perform(*options[:payload_handler].payload(message))
+    end
+
+    def perform_batch_job(klass, messages)
+      klass.perform(messages.map {|m|options[:payload_handler].payload(m)})
     end
   end
 end

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -194,7 +194,7 @@ module Chore
     end
 
     def perform_batch_job(klass, messages)
-      klass.perform(messages.map {|m|options[:payload_handler].payload(m)})
+      klass.perform(messages.flat_map {|m|options[:payload_handler].payload(m)})
     end
   end
 end


### PR DESCRIPTION
@Tapjoy/eng-group-services 
@StabbyCutyou 

Here's the beginnings of an implementation of batched job handling using a subclassed worker. To use this, simply configure your chore consumer/worker process with the new batched strategy, and implement the `perform_batch` method on your jobs.

Looking for feedback on the approach here.

Todo:
- specs
- docs (comments and otherwise)
- partial failure handling (maybe `#perform_batch` should accept a map of job id => body, and return a report of job_id => status?)
- maybe some more refactoring around `#perform_batch`
- maybe `Job` should be subclassed to `BatchJob` with better primitives around partial failure/success handling?