### PR TITLE
Add support for configuring the consumer batch_timeout

### DIFF
--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -33,6 +33,7 @@ module Chore #:nodoc:
     :consumer              => Queues::SQS::Consumer,
     :fetcher               => Fetcher,
     :consumer_strategy     => Strategy::ThreadedConsumerStrategy,
+    :batch_timeout         => 20,
     :batch_size            => 50,
     :log_level             => Logger::WARN,
     :log_path              => STDOUT,

--- a/lib/chore/strategies/consumer/batcher.rb
+++ b/lib/chore/strategies/consumer/batcher.rb
@@ -22,7 +22,7 @@ module Chore
       # If the +batch_timeout+ has elapsed, as soon as the next message enters the batch, it will be executed.
       # 
       # Calling <tt>stop</tt> will cause the thread to finish it's current check, and exit
-      def schedule(batch_timeout=20)
+      def schedule(batch_timeout)
         @thread = Thread.new(batch_timeout) do |timeout|
           Chore.logger.info "Batching timeout thread starting"
           while @running do

--- a/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
@@ -5,13 +5,14 @@ module Chore
       attr_accessor :batcher
 
       Chore::CLI.register_option 'batch_size', '--batch-size SIZE', Integer, 'Number of items to collect for a single worker to process'
+      Chore::CLI.register_option 'batch_timeout', '--batch-timeout TIMEOUT', Integer, 'Maximum amount of time in seconds to spend collecting items in a batch, if the batch_size is not reached'
       Chore::CLI.register_option 'threads_per_queue', '--threads-per-queue NUM_THREADS', Integer, 'Number of threads to create for each named queue'
 
       def initialize(fetcher)
         @fetcher = fetcher
         @batcher = Batcher.new(Chore.config.batch_size)
         @batcher.callback = lambda { |batch| @fetcher.manager.assign(batch) }
-        @batcher.schedule
+        @batcher.schedule(Chore.config.batch_timeout)
         @running = true
       end
 


### PR DESCRIPTION
@Tapjoy/eng-group-services 

This adds support for configuring the consumer `batch_timeout`. This is the maximum amount of time that the consumer will wait while consuming to complete a full batch of size `batch_size`. A batch is released to the worker when either `batch_size` is reached or `batch_timeout`. This is existing functionality; the only change is to build the last mile of track to the config.