### PR TITLE
Memoize #methods in hook processing

### DIFF
--- a/lib/chore/hooks.rb
+++ b/lib/chore/hooks.rb
@@ -15,7 +15,13 @@ module Chore
 
   private
     def hooks_for(event)
-      (self.methods - Object.methods).grep(/^#{event}/).sort
+      candidate_methods.grep(/^#{event}/).sort
+    end
+
+    # NOTE: Any hook methods defined after this is first referenced (i.e.,
+    # after chore begins processing jobs) will not be called.
+    def candidate_methods
+      @_chore_hooks_candidate_methods ||= (self.methods - Object.methods)
     end
 
     def global_hooks_for(event)


### PR DESCRIPTION
hi @Tapjoy/eng-group-services 
cc @StabbyCutyou 

This improves performance significantly (when we're not waiting on network I/O).

This does involve a slight change of behavior: hook methods defined dynamically after jobs begin processing will no longer be called. I think this is reasonable.