### PR TITLE
If the single worker raises an exception, ensure that it is released

### DIFF
--- a/lib/chore/strategies/worker/single_worker_strategy.rb
+++ b/lib/chore/strategies/worker/single_worker_strategy.rb
@@ -21,13 +21,20 @@ module Chore
         worker.stop! if worker
       end
 
-      # Assigns work if there isn't already a worker in progress. Otherwise, is a noop
+      # Assigns work if there isn't already a worker in progress. In this, the
+      # single worker strategy, this should never be called if the worker is in
+      # progress.
       def assign(work)
         if workers_available?
-          @worker = Worker.new(work, @options)
-          @worker.start
-          @worker = nil
-          true
+          begin
+            @worker = Worker.new(work, @options)
+            @worker.start
+            true
+          ensure
+            @worker = nil
+          end
+        else
+          Chore.logger.error { "#{self.class}#assign: single worker is unavailable, but assign has been re-entered: #{caller * "\n"}" }
         end
       end
 

--- a/lib/chore/strategies/worker/single_worker_strategy.rb
+++ b/lib/chore/strategies/worker/single_worker_strategy.rb
@@ -27,7 +27,7 @@ module Chore
       def assign(work)
         if workers_available?
           begin
-            @worker = Worker.new(work, @options)
+            @worker = worker_klass.new(work, @options)
             @worker.start
             true
           ensure
@@ -36,6 +36,10 @@ module Chore
         else
           Chore.logger.error { "#{self.class}#assign: single worker is unavailable, but assign has been re-entered: #{caller * "\n"}" }
         end
+      end
+
+      def worker_klass
+        Worker
       end
 
       # Returns true if there is currently no worker


### PR DESCRIPTION
@Tapjoy/eng-group-services 
cc @StabbyCutyou 

We got another bad job file—and no more work was being processed, without error. This addresses that issue.