### PR TITLE
Allow single worker strategy to be used in conjunction with multiple consumer threads

### DIFF
--- a/lib/chore/strategies/worker/single_worker_strategy.rb
+++ b/lib/chore/strategies/worker/single_worker_strategy.rb
@@ -10,7 +10,10 @@ module Chore
       def initialize(manager, opts={})
         @options = opts
         @manager = manager
+        @stopped = false
         @worker = nil
+        @queue = Queue.new
+        @queue << :worker
       end
 
       # Starts the <tt>SingleWorkerStrategy</tt>. Currently a noop
@@ -18,6 +21,11 @@ module Chore
 
       # Stops the <tt>SingleWorkerStrategy</tt> if there is a worker to stop
       def stop!
+        return if @stopped
+
+        @stopped = true
+        Chore.logger.info { "Manager #{Process.pid} stopping" }
+
         worker.stop! if worker
       end
 
@@ -25,16 +33,14 @@ module Chore
       # single worker strategy, this should never be called if the worker is in
       # progress.
       def assign(work)
-        if workers_available?
-          begin
-            @worker = worker_klass.new(work, @options)
-            @worker.start
-            true
-          ensure
-            @worker = nil
-          end
-        else
-          Chore.logger.error { "#{self.class}#assign: single worker is unavailable, but assign has been re-entered: #{caller * "\n"}" }
+        return unless acquire_worker
+
+        begin
+          @worker = worker_klass.new(work, @options)
+          @worker.start
+          true
+        ensure
+          release_worker
         end
       end
 
@@ -42,9 +48,25 @@ module Chore
         Worker
       end
 
-      # Returns true if there is currently no worker
-      def workers_available?
-        @worker.nil?
+      private
+
+      # Attempts to essentially acquire a lock on a worker.  If no workers are
+      # available, then this will block until one is.
+      def acquire_worker
+        result = @queue.pop
+
+        if @stopped
+          # Strategy has stopped since the worker was acquired
+          release_worker
+          nil
+        else
+          result
+        end
+      end
+
+      # Releases the lock on a worker so that another thread can pick it up.
+      def release_worker
+        @queue << :worker
       end
     end
   end

--- a/spec/chore/strategies/worker/single_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/single_worker_strategy_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe Chore::Strategy::SingleWorkerStrategy do
   let(:manager) { double('Manager') }
+  let(:job_timeout) { 60 }
+  let(:job) { Chore::UnitOfWork.new(SecureRandom.uuid, 'test', job_timeout, Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])), 0) }
   subject       { described_class.new(manager) }
 
   describe '#stop!' do
@@ -31,4 +33,27 @@ describe Chore::Strategy::SingleWorkerStrategy do
     end
   end
 
+  describe '#assign' do
+    let(:worker) { double('Worker', start: nil) }
+
+    it 'starts a new worker' do
+      expect(Chore::Worker).to receive(:new).with(job, {}).and_return(worker)
+      subject.assign(job)
+    end
+
+    it 'can be called multiple times' do
+      expect(Chore::Worker).to receive(:new).twice.with(job, {}).and_return(worker)
+      2.times { subject.assign(job) }
+    end
+
+    it 'should release the worker if an exception occurs' do
+      allow_any_instance_of(Chore::Worker).to receive(:start).and_raise(ArgumentError)
+      expect(subject).to receive(:release_worker)
+
+      begin
+        subject.assign(job)
+      rescue ArgumentError
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a fix for the issue where having multiple consumer threads in conjunction with a single worker strategy can cause work to be left by the side because we don't have any locking around the worker.  This effectively imitates what's being done in the forked worker strategy.

I've decided to not do any refactoring around how some of the logic here is similar to the forked worker strategy.  I think there's a larger thought here around replacing the single worker strategy with a threaded worker strategy -- and getting us to a place where that shares much of the same code as the forked worker strategy.  That's a problem for another day, though.

In the meantime this should at least resolve this particular failure with multiple consumer threads.

/to @StabbyCutyou 
/fyi @Tapjoy/eng-group-services 