### PR TITLE
Add before_start hook for running callbacks prior to starting consuming / processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,13 @@ A number of hooks, both global and per-job, exist in Chore for your convenience.
 
 Global Hooks:
 
+* before_start
 * before_first_fork
 * before_fork
 * after_fork
 * around_fork
 * within_fork
+* before_shutdown
 
 ("within_fork" behaves similarly to around_fork, except that it is called after the worker process has been forked. In contrast, around_fork is called by the parent process.)
 

--- a/lib/chore/manager.rb
+++ b/lib/chore/manager.rb
@@ -18,6 +18,7 @@ module Chore
 
     # Start the Manager. This calls both the #start method of the configured Worker Strategy, as well as Fetcher#start.
     def start
+      Chore.run_hooks_for(:before_start)
       @started_at = Time.now
       @worker_strategy.start
       @fetcher.start


### PR DESCRIPTION
This adds a `before_start` hook that mirrors the `before_shutdown` hook.  It will run callbacks prior to starting the fetcher / worker strategy (which are responsible for consuming and processing jobs).  This is particularly useful for integrations like NewRelic where we can have a single hook that works regardless of the worker strategy in use.  Currently, NewRelic integrations must hook into the `before_first_fork` hook which doesn't work if you're not using a forked strategy.

/to @StabbyCutyou @theo-lanman 
/cc @Tapjoy/eng-group-services 