### PR TITLE
Use multi_json instead of forcing usage of the json library

### DIFF
--- a/chore-core.gemspec
+++ b/chore-core.gemspec
@@ -36,11 +36,12 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.25"
   s.summary = "Job processing... for the future!"
 
-  s.add_runtime_dependency(%q<json>, [">= 0"])
+  s.add_runtime_dependency(%q<multi_json>, [">= 0"])
   s.add_runtime_dependency(%q<aws-sdk-v1>, ["~> 1.56", ">= 1.56.0"])
   s.add_runtime_dependency(%q<thread>, ["~> 0.1.3"])
   s.add_development_dependency(%q<rspec>, ["~> 3.3.0"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
   s.add_development_dependency(%q<bundler>, [">= 0"])
+  s.add_development_dependency(%q<json>, [">= 0"])
 end
 

--- a/chore.gemspec
+++ b/chore.gemspec
@@ -36,11 +36,12 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.25"
   s.summary = "Job processing... for the future!"
 
-  s.add_runtime_dependency(%q<json>, [">= 0"])
+  s.add_runtime_dependency(%q<multi_json>, [">= 0"])
   s.add_runtime_dependency(%q<aws-sdk-v1>, ["~> 1.56", ">= 1.56.0"])
   s.add_runtime_dependency(%q<thread>, ["~> 0.1.3"])
   s.add_development_dependency(%q<rspec>, ["~> 2.12.0"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
   s.add_development_dependency(%q<bundler>, [">= 0"])
+  s.add_development_dependency(%q<json>, [">= 0"])
 end
 

--- a/lib/chore/encoders/json_encoder.rb
+++ b/lib/chore/encoders/json_encoder.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 
 module Chore
   module Encoder
@@ -7,12 +7,12 @@ module Chore
       class << self
         # Encodes the +job+ into JSON using the standard ruby JSON parsing library
         def encode(job)
-          JSON.generate(job.to_hash)
+          MultiJson.dump(job.to_hash)
         end
 
         # Decodes the +job+ from JSON into a ruby Hash using the standard ruby JSON parsing library
         def decode(job)
-          JSON.parse(job)
+          MultiJson.load(job)
         end
       end
     end

--- a/spec/chore/worker_spec.rb
+++ b/spec/chore/worker_spec.rb
@@ -112,7 +112,7 @@ describe Chore::Worker do
 
     context 'on perform' do
       let(:encoded_job) { Chore::Encoder::JsonEncoder.encode(job) }
-      let(:parsed_job) { JSON.parse(encoded_job) }
+      let(:parsed_job) { MultiJson.load(encoded_job) }
 
       before(:each) do
         SimpleJob.stub(:perform).and_raise(ArgumentError)
@@ -145,7 +145,7 @@ describe Chore::Worker do
 
   describe 'delaying retries' do
     let(:encoded_job) { Chore::Encoder::JsonEncoder.encode(job) }
-    let(:parsed_job) { JSON.parse(encoded_job) }
+    let(:parsed_job) { MultiJson.load(encoded_job) }
     let(:work) { Chore::UnitOfWork.new(2, 'test', 60, encoded_job, 0, consumer) }
 
     before(:each) do


### PR DESCRIPTION
`chore` currently requires that developers use the `json` library.  This makes it a bit more difficult to use alternative libraries like `oj`.  This updates chore's dependencies to use `multi_json` instead of `json`.  `json` remains a development dependency for testing purposes.

This will require a minor version bump.

/to @StabbyCutyou @theo-lanman 