### PR TITLE
Improvements to filesystem queue handling

### DIFF
--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -108,7 +108,7 @@ module Chore
 
         def complete(id)
           Chore.logger.debug "Completing (deleting): #{id}"
-          FileUtils.rm(File.join(@in_progress_dir, id))
+          FileUtils.rm_f(File.join(@in_progress_dir, id))
         end
 
         private

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -27,9 +27,6 @@ module Chore
               if f.flock(File::LOCK_EX | File::LOCK_NB) && f.size == 0
                 begin
                   f.write(encoded_job)
-                rescue StandardError => e
-                  Chore.logger.error "#{e.class.name}: #{e.message}. Could not write #{job[:class]} job to '#{queue_name}' queue file."
-                  Chore.logger.error e.backtrace.join("\n")
                 ensure
                   f.flock(File::LOCK_UN)
                 end

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -16,6 +16,9 @@ module Chore
         # use of mutex and file locking should make this both threadsafe and safe for multiple
         # processes to use the same queue directory simultaneously. 
         def publish(queue_name,job)
+          # First try encoding the job to avoid writing empty job files if this fails
+          encoded_job = job.to_json
+
           FILE_MUTEX.synchronize do
             while true
               # keep trying to get a file with nothing in it meaning we just created it
@@ -23,7 +26,7 @@ module Chore
               f = File.open(filename(queue_name, job[:class].to_s), "w")
               if f.flock(File::LOCK_EX | File::LOCK_NB) && f.size == 0
                 begin
-                  f.write(job.to_json)
+                  f.write(encoded_job)
                 rescue StandardError => e
                   Chore.logger.error "#{e.class.name}: #{e.message}. Could not write #{job[:class]} job to '#{queue_name}' queue file."
                   Chore.logger.error e.backtrace.join("\n")

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -17,7 +17,7 @@ module Chore
         # processes to use the same queue directory simultaneously. 
         def publish(queue_name,job)
           # First try encoding the job to avoid writing empty job files if this fails
-          encoded_job = job.to_json
+          encoded_job = encode_job(job)
 
           FILE_MUTEX.synchronize do
             while true


### PR DESCRIPTION
Some proposals to make the way we publisher to / consumer from the filesystem queue to be consistent with other places in chore:
1. Encode jobs with `encode_job` rather than `to_json`
2. Don't swallow errors when writing to the job file
3. Encode the job before creating a job file so as to avoid the possibility of empty job files on encoding failures
4. Use `rm -f` when deleting job files

This should make it more consistent with the general way we handling jobs in sqs (we don't swallow errors, we use `encode_job`, etc.)

/to @StabbyCutyou @theo-lanman @gregorysabatino 