### PR TITLE
Reject failed jobs in the consumer

### DIFF
--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -66,6 +66,7 @@ module Chore
             item.consumer.complete(item.id)
           else
             Chore.run_hooks_for(:on_failure,item.message,e)
+            item.consumer.reject(item.id)
           end
         end
       end
@@ -116,6 +117,7 @@ module Chore
         item.consumer.complete(item.id)
       else
         klass.run_hooks_for(:on_failure, message, e)
+        item.consumer.reject(item.id)
       end
     end
 

--- a/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
@@ -8,8 +8,18 @@ describe Chore::Strategy::ForkedWorkerStrategy do
     allow(strategy).to receive(:exit!)
     strategy
   end
+  let(:consumer) { double('consumer', :complete => nil, :reject => nil) }
   let(:job_timeout) { 60 }
-  let(:job) { Chore::UnitOfWork.new(SecureRandom.uuid, 'test', job_timeout, Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])), 0) }
+  let(:job) do
+    Chore::UnitOfWork.new(
+      SecureRandom.uuid,
+      'test',
+      job_timeout,
+      Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])),
+      0,
+      consumer
+    )
+  end
   let!(:worker) { Chore::Worker.new(job) }
   let(:pid) { Random.rand(2048) }
 


### PR DESCRIPTION
We should be calling the `#reject` API in the consumer when a job fails.  As per the documentation, `#reject` "should put a message back on a queue to be processed again later".  When a job fails, this is exactly what we want to happen.  Now, in the SQS case this is a no-op because there's no concept for that type of functionality -- you just wait a little while and the job will be back in the queue.

However, in the filesystem case, you must explicitly put the job back into the queue.  Without this change, any job that raises an exception will be stuck in "inprogress" until chore is restarted.  With this change in place, the job will be moved back to "new" and ready to be re-processed.  That does mean that jobs will get *immediately* re-processes, but I think that's better than being stuck in inprogress forever.

More testing still needed.

/to @StabbyCutyou @theo-lanman @gregorysabatino 