### PR TITLE
Change batch timeouts to be both configurable and based on the time oldest message

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Other options include:
     --threads-per-queue 4 # number of threads per queue for consuming from a given queue.
     --dedupe-servers # if using SQS or similiar queue with at-least once delivery and your memcache is running on something other than localhost
     --batch-size 50 # how many messages are batched together before handing them to a worker
+    --batch-timeout 20 # maximum number of seconds to wait until handing a message over to a worker
     --queue_prefix prefixy # A prefix to prepend to queue names, mainly for development and qa testing purposes
     --max-attempts 100 # The maximum number of times a job can be attempted
     --dupe-on-cache-failure # Determines the deduping behavior when a cache connection error occurs. When set to `false`, the message is assumed not to be a duplicate. Defaults to `false`.
@@ -92,6 +93,7 @@ Chore.configure do |c|
   c.max_attempts = 100
   ...
   c.batch_size = 50
+  c.batch_timeout = 20
 end
 ```
 

--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -34,6 +34,7 @@ module Chore #:nodoc:
     :fetcher               => Fetcher,
     :consumer_strategy     => Strategy::ThreadedConsumerStrategy,
     :batch_size            => 50,
+    :batch_timeout         => 20,
     :log_level             => Logger::WARN,
     :log_path              => STDOUT,
     :default_queue_timeout => (12 * 60 * 60), # 12 hours
@@ -186,6 +187,7 @@ module Chore #:nodoc:
   #   Chore.configure do |c|
   #     c.consumer = Chore::Queues::SQS::Consumer
   #     c.batch_size = 50
+  #     c.batch_timeout = 20
   #   end
   def self.configure(opts={})
     @config = (@config ? @config.merge_hash(opts) : Chore::Configuration.new(DEFAULT_OPTIONS.merge(opts)))

--- a/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
@@ -5,13 +5,14 @@ module Chore
       attr_accessor :batcher
 
       Chore::CLI.register_option 'batch_size', '--batch-size SIZE', Integer, 'Number of items to collect for a single worker to process'
+      Chore::CLI.register_option 'batch_timeout', '--batch-timeout SIZE', Integer, 'Maximum number of seconds to wait until processing a message'
       Chore::CLI.register_option 'threads_per_queue', '--threads-per-queue NUM_THREADS', Integer, 'Number of threads to create for each named queue'
 
       def initialize(fetcher)
         @fetcher = fetcher
         @batcher = Batcher.new(Chore.config.batch_size)
         @batcher.callback = lambda { |batch| @fetcher.manager.assign(batch) }
-        @batcher.schedule
+        @batcher.schedule(Chore.config.batch_timeout)
         @running = true
       end
 

--- a/lib/chore/unit_of_work.rb
+++ b/lib/chore/unit_of_work.rb
@@ -9,6 +9,14 @@ module Chore
   # * +:consumer+ The consumer instance used to fetch this message. Most queue implementations won't need access to this, but some (RabbitMQ) will. So we
   # make sure to pass it along with each message. This instance will be used by the Worker for things like <tt>complete</tt> and </tt>reject</tt>.
   class UnitOfWork < Struct.new(:id,:queue_name,:queue_timeout,:message,:previous_attempts,:consumer,:decoded_message, :klass)
+    # The time at which this unit of work was created
+    attr_accessor :created_at
+
+    def initialize(*) #:nodoc:
+      super
+      @created_at = Time.now
+    end
+
     # The current attempt number for the worker processing this message.
     def current_attempt
       previous_attempts + 1

--- a/spec/chore/strategies/consumer/threaded_consumer_strategy_spec.rb
+++ b/spec/chore/strategies/consumer/threaded_consumer_strategy_spec.rb
@@ -51,6 +51,7 @@ describe Chore::Strategy::ThreadedConsumerStrategy do
       work.message.should == "test"
       work.previous_attempts.should == 0
       work.current_attempt.should == 1
+      work.created_at.should_not be_nil
     end
   end
 


### PR DESCRIPTION
This makes two changes:
1. The batch timeouts are now configurable instead of being hard-coded to 20s
2. We now run `execute` when the oldest message in the batcher has exceeded the timeout.

To provide a little context, the current behavior of the timeout is that it is based on the newest message in the batcher.  Consider the scenario where batch size = 10 and timeout = 1m.  If a message came in every 30s, then the batch wouldn't be processed until 5m has passed (because the batch size will then be 10).

I will also be looking for feedback / guidance on whether this should be a minor or major rev change.

/to @gregorysabatino @theo-lanman @StabbyCutyou 