### PR TITLE
Preforked worker and throttled consumer strategies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ group :development do
 end
 
 gem 'ci_reporter', '~> 1.9.0'
+gem 'get_process_mem', '~> 0.2.0'

--- a/chore-core.gemspec
+++ b/chore-core.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<json>, [">= 0"])
   s.add_runtime_dependency(%q<aws-sdk-v1>, ["~> 1.56", ">= 1.56.0"])
   s.add_runtime_dependency(%q<thread>, ["~> 0.1.3"])
+  s.add_runtime_dependency('get_process_mem', ["~> 0.2.0"])
   s.add_development_dependency(%q<rspec>, ["~> 3.3.0"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
   s.add_development_dependency(%q<bundler>, [">= 0"])

--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -41,7 +41,7 @@ module Chore #:nodoc:
     :shutdown_timeout      => (2 * 60),
     :max_attempts          => 1.0 / 0.0, # Infinity
     :dupe_on_cache_failure => false,
-    :payload_handler => Chore::Job
+    :payload_handler       => Chore::Job
   }
 
   class << self
@@ -111,9 +111,9 @@ module Chore #:nodoc:
   #   add_hook(:before_fork) {|worker| puts 1 }
   #   add_hook(:before_fork) {|worker| puts 2 }
   #   add_hook(:before_fork) {|worker| puts 3 }
-  #   
+  #
   #   run_hooks_for(:before_fork, worker)
-  #   
+  #
   #   # ...will produce the following output
   #   => 1
   #   => 2
@@ -130,9 +130,9 @@ module Chore #:nodoc:
   #   add_hook(:around_fork) {|worker, &block| puts 'before 1'; block.call; puts 'after 1'}
   #   add_hook(:around_fork) {|worker, &block| puts 'before 2'; block.call; puts 'after 2'}
   #   add_hook(:around_fork) {|worker, &block| puts 'before 3'; block.call; puts 'after 3'}
-  #   
+  #
   #   run_hooks_for(:around_fork, worker) { puts 'block' }
-  #   
+  #
   #   # ...will produce the following output
   #   => before 1
   #   => before 2

--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -89,6 +89,7 @@ module Chore #:nodoc:
       detect_queues
       Chore.configure(options)
       Chore.configuring = false
+      validate_strategy!
     end
 
 
@@ -254,7 +255,6 @@ module Chore #:nodoc:
     end
 
     def validate! #:nodoc:
-
       missing_option!("--require [PATH|DIR]") unless options[:require]
 
       if !File.exist?(options[:require]) ||
@@ -266,7 +266,25 @@ module Chore #:nodoc:
         puts @parser
         exit(1)
       end
+    end
 
+    def validate_strategy!
+      consumer_strategy = Chore.config.consumer_strategy.to_s
+      worker_strategy = Chore.config.worker_strategy.to_s
+
+      throttled_consumer = 'Chore::Strategy::ThrottledConsumerStrategy'
+      preforked_worker = 'Chore::Strategy::PreForkedWorkerStrategy'
+
+      if consumer_strategy == throttled_consumer || worker_strategy == preforked_worker
+        unless consumer_strategy == throttled_consumer && worker_strategy == preforked_worker
+          puts "=================================================================="
+          puts "  PreForkedWorkerStrategy may only be paired with   "
+          puts "  ThrottledConsumerStrategy or vice versa  "
+          puts "  Please check your configurations "
+          puts "=================================================================="
+          exit(1)
+        end
+      end
     end
   end
 end

--- a/lib/chore/consumer.rb
+++ b/lib/chore/consumer.rb
@@ -53,5 +53,10 @@ module Chore
     def running?
       @running
     end
+
+    # returns up to n work
+    def provide_work(n)
+      raise NotImplementedError
+    end
   end
 end

--- a/lib/chore/fetcher.rb
+++ b/lib/chore/fetcher.rb
@@ -33,5 +33,10 @@ module Chore
     def stopping?
       @stopping
     end
+
+    # returns upto n work units
+    def provide_work(n)
+      @strategy.provide_work(n)
+    end
   end
 end

--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -116,9 +116,7 @@ module Chore
         def sqs
           @sqs ||= AWS::SQS.new(
             :access_key_id => Chore.config.aws_access_key,
-            :secret_access_key => Chore.config.aws_secret_key,
-            :logger => Chore.logger,
-            :log_level => :debug)
+            :secret_access_key => Chore.config.aws_secret_key)
         end
 
         def sqs_polling_amount

--- a/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
@@ -64,6 +64,7 @@ module Chore
               Chore.logger.debug { "Got message: #{id}"}
 
               work = UnitOfWork.new(id, queue_name, queue_timeout, body, previous_attempts, consumer)
+              Chore.run_hooks_for(:consumed_from_source, work)
               @batcher.add(work)
             end
           rescue Chore::TerribleMistake

--- a/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
@@ -1,0 +1,105 @@
+module Chore
+  module Strategy
+    class ThrottledConsumerStrategy #:nodoc:
+      def initialize(fetcher)
+        @fetcher = fetcher
+        @queue = SizedQueue.new(Chore.config.num_workers)
+        @max_queue_size = Chore.config.num_workers
+        @consumers_per_queue = Chore.config.threads_per_queue
+        @running = true
+        @consumers = []
+      end
+
+      # Begins fetching from queues by spinning up the configured
+      # +:threads_per_queue:+ count of threads for each
+      # queue you're consuming from.
+      # Once all threads are spun up and running, the threads are then joined.
+
+      def fetch
+        Chore.logger.info "TCS: Starting up: #{self.class.name}"
+        threads = []
+        Chore.config.queues.each do |consume_queue|
+          Chore.logger.info "TCS: Starting #{@consumers_per_queue} threads for Queue #{consume_queue}"
+          @consumers_per_queue.times do
+            next unless running?
+            threads << consume(consume_queue)
+          end
+        end
+        threads.each(&:join)
+      end
+
+      # If the ThreadedConsumerStrategy is currently running <tt>stop!</tt>
+      # will begin signalling it to stop. It will stop the batcher
+      # from forking more work,as well as set a flag which will disable
+      # it's own consuming threads once they finish with their current work.
+      def stop!
+        if running?
+          Chore.logger.info "TCS: Shutting down fetcher: #{self.class.name}"
+          @running = false
+          @consumers.each do |consumer|
+            Chore.logger.info "TCS: Stopping consumer: #{consumer.object_id}"
+            @queue.clear
+            consumer.stop
+          end
+        end
+      end
+
+      # Returns whether or not the ThreadedConsumerStrategy is running or not
+      def running?
+        @running
+      end
+
+      # return upto number_of_free_workers work objects
+      def provide_work(no_free_workers)
+        work_units = []
+        free_workers = [no_free_workers, @queue.size].min
+        while free_workers > 0
+          work_units << @queue.pop
+          free_workers -= 1
+        end
+        work_units
+      end
+
+      private
+
+      def consume(consume_queue)
+        consumer = Chore.config.consumer.new(consume_queue)
+        @consumers << consumer
+        start_consumer_thread(consumer)
+      end
+
+      # Starts a consumer thread for polling the given +consume_queue+.
+      # If <tt>stop!<tt> is called, the threads will shut themsevles down.
+      def start_consumer_thread(consumer)
+        t = Thread.new(consumer) do |th|
+          begin
+            create_work_units(th)
+          rescue Chore::TerribleMistake => e
+            Chore.logger.error 'Terrible mistake, shutting down Chore'
+            Chore.logger.error "#{e.inspect} at #{e.backtrace}"
+            @fetcher.manager.shutdown!
+          end
+        end
+        t
+      end
+
+      def create_work_units(consumer)
+        consumer.consume do |id, queue, timeout, body, previous_attempts|
+          # Note: The unit of work object contains a consumer object that when 
+          # used to consume from SQS, would have a mutex (that comes as a part 
+          # of the AWS sdk); When sending these objects across from one process 
+          # to another, we cannot send this across (becasue of the mutex). To 
+          # work around this, we simply ignore the consumer object when creating
+          # the unit of work object, and when the worker recieves the work 
+          # object, it assigns it a consumer object. 
+          # (to allow for communication back to the queue it was consumed from)
+          work = UnitOfWork.new(id, queue, timeout, body,
+                                previous_attempts)
+          Chore.run_hooks_for(:consumed_from_source, work)
+          @queue.push(work) if running?
+          Chore.run_hooks_for(:added_to_queue, work)
+        end
+      end
+    end # ThrottledConsumerStrategyyeah 
+  end
+end # Chore

--- a/lib/chore/strategies/worker/helpers/ipc.rb
+++ b/lib/chore/strategies/worker/helpers/ipc.rb
@@ -1,0 +1,86 @@
+require 'socket'
+
+module Chore
+  module Strategy
+    module Ipc #:nodoc:
+      BIG_ENDIAN = 'L>'.freeze
+      MSG_BYTES = 4
+
+      def create_master_socket
+        File.delete socket_file if File.exist? socket_file
+        UNIXServer.new(socket_file).tap do | socket |
+          socket_options(socket)
+        end
+      end
+
+      def child_connection(socket)
+        socket.accept
+      end
+
+      # Sending a message to a socket (must be a connected socket)
+      def send_msg(socket, msg)
+        raise 'send_msg cannot send empty messages' if msg.nil? || msg.size == 0
+        message = Marshal.dump(msg)
+        encoded_size = [message.size].pack(BIG_ENDIAN)
+        encoded_message = "#{encoded_size}#{message}"
+        socket.send encoded_message, 0
+      end
+
+      # read a message from socket (must be a connected socket)
+      def read_msg(socket)
+        encoded_size = socket.recv(MSG_BYTES, Socket::MSG_PEEK)
+        return if encoded_size.nil? || encoded_size == ''
+
+        size = encoded_size.unpack(BIG_ENDIAN).first
+        encoded_message = socket.recv(MSG_BYTES + size)
+        Marshal.load(encoded_message[MSG_BYTES..-1])
+      rescue Errno::ECONNRESET => ex
+        Chore.logger.info "IPC: Connection was closed on socket #{socket}"
+        raise ex
+      end
+
+      def add_worker_socket
+        UNIXSocket.new(socket_file).tap do | socket |
+          socket_options(socket)
+        end
+      end
+
+      def clear_ready(socket)
+        _ = socket.gets
+      end
+
+      def signal_ready(socket)
+        socket.puts 'R'
+      rescue Errno::EPIPE => ex
+        Chore.logger.info 'IPC: Connection was shutdown by master'
+        raise ex
+      end
+
+      def select_sockets(sockets, self_pipe = nil, timeout = 0.5)
+        all_socks = [sockets, self_pipe].flatten.compact
+        IO.select(all_socks, nil, all_socks, timeout)
+      end
+
+      def delete_socket_file
+        Chore.logger.info 'IPC: Removing socket file'
+        File.unlink(socket_file)
+      end
+
+      # Used for unit tests
+      def ipc_help
+        :available
+      end
+
+      private
+
+      # TODO do we need this as a optional param
+      def socket_file
+        "./prefork_worker_sock-#{Process.pid}"
+      end
+
+      def socket_options(socket)
+        socket.setsockopt(:SOCKET, :REUSEADDR, true)
+      end
+    end
+  end
+end

--- a/lib/chore/strategies/worker/helpers/preforked_worker.rb
+++ b/lib/chore/strategies/worker/helpers/preforked_worker.rb
@@ -1,0 +1,157 @@
+require 'chore/signal'
+require 'socket'
+require 'timeout'
+require 'chore/strategies/worker/helpers/ipc'
+
+module Chore
+  module Strategy
+    class PreforkedWorker #:nodoc:
+      include Util
+      include Ipc
+
+      NUM_TO_SIGNAL = {'2' => :INT, '3' => :QUIT, '4' => :TERM}.freeze
+
+      def initialize(_opts = {})
+        @manager_pid = Process.ppid
+        @consumer_cache = {}
+        @running = true
+        post_fork_setup
+      end
+
+      def start_worker(master_socket)
+        Chore.logger.info 'PFW: Worker starting'
+        raise 'PFW: Did not get master_socket' unless master_socket
+        connection = connect_to_master(master_socket)
+        worker(connection)
+      rescue => e
+        Chore.logger.error "PFW: Shutting down #{e.message} #{e.backtrace}"
+        raise e
+      end
+
+      private
+
+      def worker(connection)
+        worker_killer = WorkerKiller.new
+        while running?
+          # Select on the connection to the master and the self pipe
+          readables, _, ex = select_sockets(connection, nil, Chore.config.shutdown_timeout)
+
+          if readables.nil? # timeout
+            next
+          end
+
+          read_socket = readables.first
+
+          # Get the work from the connection to master
+          work = read_msg(read_socket)
+
+          # When the Master (manager process) dies, the sockets are set to
+          # readable, but there is no data in the socket. In this case we check
+          # to see if the manager is actually dead, and in that case, we exit.
+          if work.nil? && is_orphan?
+            Chore.logger.info "PFW: Manager no longer alive; Shutting down"
+            break
+          end
+
+          unless work.nil?
+            # Do the work
+            process_work(work)
+
+            worker_killer.check_requests
+            worker_killer.check_memory
+
+            # Alert master that worker is ready to receive more work
+            signal_ready(read_socket)
+
+          end
+        end
+        Chore.logger.debug "PFW: Master process terminating"
+        exit(true)
+      rescue Errno::ECONNRESET, Errno::EPIPE
+        Chore.logger.info "PFW: Worker-#{Process.pid} lost connection to master, shutting down"
+        exit(true)
+      end
+
+      # Method wrapper around @running makes it easier to write specs
+      def running?
+        @running
+      end
+
+      # Connects to the master socket, sends its PID, send a ready for work
+      # message, and returns the connection
+      def connect_to_master(master_socket)
+        Chore.logger.info 'PFW: connect protocol started'
+        child_connection(master_socket).tap do |conn|
+          send_msg(conn, Process.pid)
+          signal_ready(conn)
+          Chore.logger.info 'PFW: connect protocol completed'
+        end
+      end
+
+      def post_fork_setup
+        # Immediately swap out the process name so that it doesn't look like
+        # the master process
+        procline("chore-worker-#{Chore::VERSION}:Started:#{Time.now}")
+
+        # We need to reset the logger after fork. This fixes a longstanding bug
+        # where workers would hang around and never die
+        Chore.logger = nil
+
+        config = Chore.config
+        # When we fork, the consumer's/publisher's need their connections reset.
+        # The specifics of this are queue dependent, and may result in a noop.
+        config.consumer.reset_connection!
+        # It is possible for this to be nil due to configuration woes with chore
+        config.publisher.reset_connection! if Chore.config.publisher
+
+        trap_signals(NUM_TO_SIGNAL)
+      end
+
+      def process_work(work)
+        work = [work] unless work.is_a?(Array)
+        work.each do |item|
+          item.consumer = consumer(item.queue_name)
+          begin
+            Timeout.timeout( item.queue_timeout ) do
+              worker = Worker.new(item)
+              worker.start
+            end
+          rescue Timeout::Error => ex
+            Chore.logger.info "PFW: Worker #{Process.pid} timed out"
+            Chore.logger.info "PFW: Worker time out set at #{item.queue_timeout} seconds"
+            exit(true)
+          end
+        end
+      end
+
+      # We need to resue Consumer objects because it takes 500ms to recreate
+      # each one.
+      def consumer(queue)
+        unless @consumer_cache.key?(queue)
+          raise Chore::TerribleMistake if @consumer_cache.size >= Chore.config.queues.size
+          @consumer_cache[queue] = Chore.config.consumer.new(queue)
+        end
+        @consumer_cache[queue]
+      end
+
+      # In the event of a trapped signal, write to the self-pipe
+      def trap_signals(signal_hash)
+        Signal.reset
+
+        signal_hash.each do |sig_num, signal|
+          Signal.trap(signal) do
+            Chore.logger.debug "PFW: received signal: #{signal}"
+            @running = false
+            sleep(Chore.config.shutdown_timeout)
+            Chore.logger.debug "PFW: Worker process terminating"
+            exit(true)
+          end
+        end
+      end
+
+      def is_orphan?
+        Process.ppid != @manager_pid
+      end
+    end
+  end
+end

--- a/lib/chore/strategies/worker/helpers/work_distributor.rb
+++ b/lib/chore/strategies/worker/helpers/work_distributor.rb
@@ -1,0 +1,51 @@
+require 'chore/strategies/worker/helpers/ipc'
+
+module Chore
+  module Strategy
+    class WorkDistributor #:nodoc:
+      class << self
+        include Ipc
+
+        def fetch_and_assign_jobs(workers, manager)
+          jobs = manager.fetch_work(workers.size)
+          raise "DW: jobs needs to be a list got #{jobs.class}" unless jobs.is_a?(Array)
+          if jobs.empty?
+            # This conditon is due to the internal consumer queue being empty.
+            # Assuming that the the consumer has to fetch from an external queue,
+            # if we return here, we would create a tight loop that would use up
+            # a lot the CPU's time. In order to prevent that, we wait for the
+            # consumer queue to be populated, by sleeping. 
+            sleep(0.1)
+            return
+          end
+          assign_jobs(jobs, workers)
+        end
+
+        private
+
+        def assign_jobs(jobs, workers)
+          raise 'DW: assign_jobs got 0 workers' if workers.empty?
+          jobs.each_with_index do |job, i|
+            raise 'DW: More Jobs than Sockets' if workers[i].nil?
+            push_job_to_worker(job, workers[i])
+          end
+        end
+
+        def push_job_to_worker(job, worker)
+          Chore.run_hooks_for(:before_send_to_worker, job)
+          clear_ready(worker.socket)
+          send_msg(worker.socket, job)
+        rescue => e
+          Chore.logger.error "DW: Could not assign job #{job.inspect}"
+        end
+
+        private
+
+        # Used for unit tests
+        def sleep(n)
+          Kernel.sleep(n)
+        end
+      end
+    end
+  end
+end

--- a/lib/chore/strategies/worker/helpers/worker_info.rb
+++ b/lib/chore/strategies/worker/helpers/worker_info.rb
@@ -1,0 +1,13 @@
+module Chore
+  module Strategy
+    class WorkerInfo
+      # Holds meta information about the worker: pid, and connection socket
+      attr_accessor :pid, :socket
+
+      def initialize(pid)
+        @pid = pid
+        @socket = nil
+      end
+    end
+  end
+end

--- a/lib/chore/strategies/worker/helpers/worker_killer.rb
+++ b/lib/chore/strategies/worker/helpers/worker_killer.rb
@@ -1,0 +1,40 @@
+require 'get_process_mem'
+
+module Chore
+  module Strategy
+    class WorkerKiller  #:nodoc:
+      def initialize
+        @memory_limit = Chore.config.memory_limit_bytes
+        @request_limit = Chore.config.request_limit
+        @check_cycle = Chore.config.worker_check_cycle || 16
+        @check_count = 0
+        @current_requests = 0
+      end
+
+      def check_memory
+        return if @memory_limit.nil? || (@memory_limit == 0)
+        @check_count += 1
+
+        if @check_count == @check_cycle
+          rss = GetProcessMem.new.bytes.to_i
+          if rss > @memory_limit
+            Chore.logger.info "WK: (pid: #{Process.pid}) exceeded memory limit (#{rss.to_i} bytes > #{@memory_limit} bytes)"
+            Chore.run_hooks_for(:worker_mem_kill)
+            exit(true)
+          end
+          @check_count = 0
+        end
+      end
+
+      def check_requests
+        return if @request_limit.nil? || (@request_limit == 0)
+
+        if (@current_requests += 1) >= @request_limit
+          Chore.logger.info "WK: (pid: #{Process.pid}) exceeded max number of requests (limit: #{@request_limit})"
+          Chore.run_hooks_for(:worker_req_kill)
+          exit(true)
+        end
+      end
+    end
+  end
+end

--- a/lib/chore/strategies/worker/helpers/worker_manager.rb
+++ b/lib/chore/strategies/worker/helpers/worker_manager.rb
@@ -1,0 +1,179 @@
+require 'chore/strategies/worker/helpers/ipc'
+
+module Chore
+  module Strategy
+    class WorkerManager #:nodoc:
+      include Ipc
+
+      def initialize(master_socket)
+        @master_socket = master_socket
+        @pid_to_worker = {}
+        @socket_to_worker = {}
+      end
+
+      # Create num of missing workers and sockets and attach them for the
+      # master
+      def create_and_attach_workers
+        create_workers do |num_workers|
+          attach_workers(num_workers)
+        end
+      end
+
+      # Reap dead workers and create new ones to replace them
+      def respawn_terminated_workers!
+        Chore.logger.debug 'WM: Respawning terminated workers'
+        reap_workers
+        create_and_attach_workers
+      end
+
+      # Stop children with the given kill signal and wait for them to die
+      def stop_workers(sig)
+        @pid_to_worker.each do |pid, worker|
+          begin
+            Chore.logger.info { "WM: Sending #{sig} to: #{pid}" }
+            Process.kill(sig, pid)
+          rescue Errno::ESRCH => e
+            Chore.logger.error "WM: Signal to children error: #{e}"
+          end
+        end
+        # TODO: Sleep for the shutdown timeout and kill any remaining workers
+        reap_workers
+      end
+
+      # Return all the worker sockets
+      def worker_sockets
+        @socket_to_worker.keys
+      end
+
+      # Return the workers associated with a given array of sockets.
+      # +block+:: A block can be provided to perform tasks on the workers
+      # associated with the sockets given
+      def ready_workers(sockets = [], &block)
+        workers = @socket_to_worker.values_at(*sockets)
+        yield workers if block_given?
+        workers
+      end
+
+      private
+
+      # Creates worker processes until we have the number of workers defined
+      # by the configuration. Initializes and starts a worker instance in each
+      # of the new processes.
+      # +block+:: Block can be provided to run tasks on the number of newly
+      # created worker processes.
+      def create_workers(&block)
+        num_created_workers = 0
+
+        while @pid_to_worker.size < Chore.config.num_workers
+          pid = fork do
+            run_worker_instance
+          end
+
+          Chore.logger.info "WM: created_worker #{pid}"
+          # Keep track of the new worker process
+          @pid_to_worker[pid] = WorkerInfo.new(pid)
+          num_created_workers += 1
+        end
+
+        raise 'WM: Not enough workers' if inconsistent_worker_number
+        Chore.logger.info "WM: created #{num_created_workers} workers"
+        yield num_created_workers if block_given?
+        num_created_workers
+      end
+
+      # Check that number of workers registered in master match the config
+      def inconsistent_worker_number
+        Chore.config.num_workers != @pid_to_worker.size
+      end
+
+      # Initialize and start a new worker instance
+      def run_worker_instance
+        PreforkedWorker.new.start_worker(@master_socket)
+      ensure
+        exit!(true)
+      end
+
+      # Creates individual sockets for each worker to use and attaches them to
+      # the correct worker
+      def attach_workers(num)
+        Chore.logger.info "WM: Started attaching #{num} workers"
+
+        create_worker_sockets(num).each do |socket|
+          begin
+            readable, _, _ = select_sockets(socket, nil, 2)
+
+            if readable.nil?
+              socket.close
+              next
+            end
+
+            r_socket = readable.first
+            reported_pid = read_msg(r_socket)
+
+            assigned_worker = @pid_to_worker[reported_pid]
+            assigned_worker.socket = socket
+            @socket_to_worker[socket] = assigned_worker
+
+            Chore.logger.debug "WM: Connected #{reported_pid} with #{r_socket}"
+          rescue Errno::ECONNRESET
+            Chore.logger.info "WM: A worker failed to connect to #{socket}"
+            socket.close
+            next
+          end
+        end
+
+        # If the connection from a worker times out, we are unable to associate
+        # the process with a connection and so we kill the worker process
+        kill_unattached_workers
+        Chore.logger.info 'WM: Finished attaching workers'
+      end
+
+      # Create num amount of sockets that are available for worker connections
+      def create_worker_sockets(num)
+        Array.new(num) do
+          add_worker_socket
+        end
+      end
+
+      # Kill workers that failed to connect to the master
+      def kill_unattached_workers
+        @pid_to_worker.each do |pid, worker|
+          next unless worker.socket.nil?
+          Process.kill('KILL', pid)
+        end
+      end
+
+      # Wait for terminated workers to die and remove their references from
+      # master
+      def reap_workers
+        dead_workers = @pid_to_worker.select do |pid, worker|
+          reap_process(pid)
+        end
+
+        dead_workers.each do |pid, worker|
+          dead_worker = @pid_to_worker.delete(pid)
+          @socket_to_worker.delete(dead_worker.socket)
+          Chore.logger.debug "WM: Removed preforked worker:#{worker.pid} - #{worker.socket}"
+        end
+      end
+
+      # Non-blocking wait for process to die. Returns whether it stopped
+      def reap_process(pid)
+        status = Process.wait(pid, Process::WNOHANG)
+        case status
+        when nil # Process is still running
+          return false
+        when pid # Collected status of this pid
+          return true
+        end
+      rescue Errno::ECHILD
+        # Child process has already terminated
+        true
+      end
+
+      def fork(&block)
+        Kernel.fork(&block)
+      end
+    end
+  end
+end

--- a/lib/chore/strategies/worker/preforked_worker_strategy.rb
+++ b/lib/chore/strategies/worker/preforked_worker_strategy.rb
@@ -1,0 +1,120 @@
+require 'chore/signal'
+require 'socket'
+require 'chore/strategies/worker/helpers/ipc'
+require 'chore/strategies/worker/helpers/preforked_worker'
+require 'chore/strategies/worker/helpers/worker_manager'
+require 'chore/strategies/worker/helpers/work_distributor'
+
+module Chore
+  module Strategy
+    class PreForkedWorkerStrategy #:nodoc:
+      include Ipc
+
+      NUM_TO_SIGNAL = {  '1' => :CHLD,
+                         '2' => :INT,
+                         '3' => :QUIT,
+                         '4' => :TERM
+                      }.freeze
+
+      def initialize(manager, opts = {})
+        @options = opts
+        @manager = manager
+        @self_read, @self_write = IO.pipe
+        trap_signals(NUM_TO_SIGNAL, @self_write)
+        @worker_manager = WorkerManager.new(create_master_socket)
+        @running = true
+      end
+
+      def start
+        Chore.logger.info "PWS: Starting up worker strategy: #{self.class.name}"
+        Chore.run_hooks_for(:before_first_fork)
+        @worker_manager.create_and_attach_workers
+        worker_assignment_thread
+      end
+
+      def stop!
+        Chore.logger.info "PWS: Stopping worker strategy: #{self.class.name}"
+        @running = false
+      end
+
+      private
+
+      def worker_assignment_thread
+        Thread.new do
+          begin
+            worker_assignment_loop
+          rescue Chore::TerribleMistake => e
+            Chore.logger.error 'PWS: Terrible mistake, shutting down Chore'
+            Chore.logger.error e.message
+            Chore.logger.error e.backtrace
+            @manager.shutdown!
+          end
+        end
+      end
+
+      def worker_assignment_loop
+        while running?
+          w_sockets = @worker_manager.worker_sockets
+
+          # select_sockets returns a list of readable sockets
+          # This would include worker connections and the read end
+          # of the self-pipe.
+          readables, _, _ = select_sockets(w_sockets, @self_read)
+
+          # If select timed out, retry
+          if readables.nil?
+            Chore.logger.debug "PWS: All sockets busy.. retry"
+            next
+          end
+
+          # Handle the signal from the self-pipe
+          if readables.include?(@self_read)
+            handle_signal
+            next
+          end
+
+          # Fetch and assign work for the readable worker connections
+          @worker_manager.ready_workers(readables) do | workers |
+            WorkDistributor.fetch_and_assign_jobs(workers, @manager)
+          end
+        end
+        delete_socket_file
+      end
+
+      # Wrapper need around running to help writing specs for worker_assignment_loop
+      def running?
+        @running
+      end
+
+      def handle_signal
+        signal = NUM_TO_SIGNAL[@self_read.read_nonblock(1)]
+        Chore.logger.debug "PWS: recv #{signal}"
+
+        case signal
+        when :CHLD
+          @worker_manager.respawn_terminated_workers!
+        when :INT, :QUIT, :TERM
+          Signal.reset
+          @worker_manager.stop_workers(signal)
+          @manager.shutdown!
+        end
+      end
+
+      # Wrapper around fork for specs.
+      def fork(&block)
+        Kernel.fork(&block)
+      end
+
+      # In the event of a trapped signal, write to the self-pipe
+      def trap_signals(signal_hash, write_end)
+        Signal.reset
+
+        signal_hash.each do |sig_num, signal|
+          Signal.trap(signal) do
+            write_end.write(sig_num)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/chore/util.rb
+++ b/lib/chore/util.rb
@@ -2,7 +2,7 @@ module Chore
 
   # Collection of utilities and helpers used by Chore internally
   module Util
-    
+
     # To avoid bringing in all of active_support, we implemented constantize here
     def constantize(camel_cased_word)
       names = camel_cased_word.split('::')
@@ -13,6 +13,10 @@ module Chore
         constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
       end
       constant
+    end
+
+    def procline(str)
+      $0 = str
     end
   end
 end

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -58,6 +58,7 @@ module Chore
         begin
           item.decoded_message = options[:payload_handler].decode(item.message)
           item.klass = options[:payload_handler].payload_class(item.decoded_message)
+          Chore.run_hooks_for(:worker_to_start, item)
           start_item(item)
         rescue => e
           Chore.logger.error { "Failed to run job for #{item.message} with error: #{e.message} #{e.backtrace * "\n"}" }
@@ -89,6 +90,7 @@ module Chore
         item.consumer.complete(item.id)
         Chore.logger.info { "Finished job #{klass} with params #{message}"}
         klass.run_hooks_for(:after_perform, message)
+        Chore.run_hooks_for(:worker_ended, item)
       rescue Job::RejectMessageException
         item.consumer.reject(item.id)
         Chore.logger.error { "Failed to run job for #{item.message}  with error: Job raised a RejectMessageException" }

--- a/scripts/monitoring
+++ b/scripts/monitoring
@@ -1,0 +1,15 @@
+#Chore utils
+alias cchore="pgrep -f '^chore-'"
+alias ctop="watch  -d -n1  'pgrep -f ^chore- | xargs ps -o user,tt,pid,lwp,nlwp,state,%cpu,%mem,start,etime,pri,flags,vsz,rss,wchan,command -Mp'"
+alias cctop="watch  -d -n1  'pgrep -f ^chore- | xargs ps -o user,tt,pid,lwp,nlwp,state,%cpu,%mem,start,etime,pri,flags,vsz,rss,wchan,command -p'"
+#
+##Workers
+alias cworkers="pgrep -f '^chore-worker'"
+alias cwtop="watch -d -n1  'pgrep -f ^chore-worker| xargs ps -o user,tt,pid,lwp,nlwp,state,%cpu,%mem,start,etime,pri,flags,vsz,rss,wchan,command -Mp'"
+alias cwkill="pgrep -f '^chore-worker'| xargs kill -9"
+alias cwquit="pgrep -f '^chore-worker'| xargs kill -QUIT"
+##masters
+alias cmaster="pgrep -f '^chore-master'"
+alias cmtop="watch -d -n1  'pgrep -f ^chore-master| xargs ps -o user,tt,pid,lwp,nlwp,state,%cpu,%mem,start,etime,pri,flags,vsz,rss,wchan,command -Mp'"
+alias cmkill="pgrep -f '^chore-master'| xargs kill -9"
+alias cmquit="pgrep -f '^chore-master'| xargs kill -QUIT"

--- a/spec/chore/queues/sqs/consumer_spec.rb
+++ b/spec/chore/queues/sqs/consumer_spec.rb
@@ -34,9 +34,7 @@ describe Chore::Queues::SQS::Consumer do
 
       expect(AWS::SQS).to receive(:new).with(
         :access_key_id => 'key',
-        :secret_access_key => 'secret',
-        :logger => Chore.logger,
-        :log_level => :debug
+        :secret_access_key => 'secret'
       ).and_return(sqs)
       consumer.consume
     end

--- a/spec/chore/strategies/consumer/throttled_consumer_strategy_spec.rb
+++ b/spec/chore/strategies/consumer/throttled_consumer_strategy_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+class TestConsumer < Chore::Consumer
+  def initialize(queue_name, opts={})
+  end
+
+  def consume
+    # just something that looks like an SQS message
+    msg = OpenStruct.new( :id => 1, :body => "test" )
+    yield msg if block_given?
+  end
+end
+
+class NoQueueConsumer < Chore::Consumer
+  def initialize(queue_name, opts={})
+    raise Chore::TerribleMistake
+  end
+
+  def consume
+  end
+end
+
+describe Chore::Strategy::ThrottledConsumerStrategy do
+  let(:fetcher) { double("fetcher") }
+  let(:manager) { double("manager") }
+  let(:thread) {double("thread")}
+  let(:consume_queue) { "TestQueue" }
+  let(:consumer) { TestConsumer }
+  let(:consumer_object) { consumer.new(consume_queue) }
+  let(:strategy) { Chore::Strategy::ThrottledConsumerStrategy.new(fetcher) }
+  let(:config) { double("config") }
+  let(:sized_queue) {double("sized_queue")}
+  let(:work) { double("work") }
+  let(:msg) { OpenStruct.new( :id => 1, :body => "test" ) }
+
+
+  before(:each) do
+    allow(fetcher).to receive(:consumers).and_return([consumer])
+    allow(fetcher).to receive(:manager).and_return(manager)
+    Chore.configure do |c| 
+      c.queues = [consume_queue] 
+      c.consumer = consumer
+    end
+  end
+
+  context '#fetch' do
+    it 'should call consume, \'@number_of_consumers\' number of times' do
+      allow(strategy).to receive(:consume).and_return(thread)
+      allow(thread).to receive(:join).and_return(true)
+      allow(Chore).to receive(:config).and_return(config)
+      allow(config).to receive(:queues).and_return([consume_queue])
+      strategy.instance_variable_set(:@consumers_per_queue, 5)
+      expect(strategy).to receive(:consume).with(consume_queue).exactly(5).times
+      strategy.fetch
+    end
+  end
+
+  context '#stop!' do
+    it 'should should stop itself, and every other consumer' do
+      allow(strategy).to receive(:running?).and_return(true)
+      strategy.instance_eval('@running = true')
+      strategy.instance_variable_set(:@consumers, [consumer_object])
+      expect(consumer_object).to receive(:stop)
+      strategy.stop!
+      expect(strategy.instance_variable_get(:@running)).to eq(false)
+    end
+  end
+
+  context '#fetch_work' do
+    it 'should return upto n units of work' do
+      n = 2
+      strategy.instance_variable_set(:@queue, sized_queue)
+      allow(sized_queue).to receive(:size).and_return(10)
+      allow(sized_queue).to receive(:pop).and_return(work)
+      expect(sized_queue).to receive(:pop).exactly(n).times
+      res = strategy.provide_work(n)
+      expect(res.size).to eq(n)
+      expect(res).to be_a_kind_of(Array)
+    end
+
+    it 'should return an empty array if no work is found in the queue' do
+      n = 2
+      strategy.instance_variable_set(:@queue, sized_queue)
+      allow(sized_queue).to receive(:size).and_return(0)
+      allow(sized_queue).to receive(:pop).and_return(work)
+      expect(sized_queue).to receive(:pop).exactly(0).times
+      res = strategy.provide_work(n)
+      expect(res.size).to eq(0)
+      expect(res).to be_a_kind_of(Array)
+    end
+  end
+
+  context '#consume' do
+    it 'should create a consumer object, add it to the list of consumers and start a consumer thread' do
+      allow(strategy).to receive(:start_consumer_thread).and_return(true)
+      expect(strategy).to receive(:start_consumer_thread)
+      strategy.send(:consume, consume_queue)
+      expect(strategy.instance_variable_get(:@consumers)).to be_a_kind_of(Array)
+      expect(strategy.instance_variable_get(:@consumers).first).to be_a_kind_of(TestConsumer)
+    end
+  end
+
+  context '#start_consumer_thread' do
+    let(:thread) { double('thread') }
+
+    it 'should create a thread' do
+      allow(Thread).to receive(:new).and_return(thread)
+      res = strategy.send(:start_consumer_thread, consumer_object)
+      expect(res).to eq(thread)
+    end
+  end
+
+  context '#create_work_units' do
+    it 'should create an unit of work from what the consumer gets, and adds it to the internal queue' do
+      strategy.instance_variable_set(:@queue, [])
+      res = strategy.send(:create_work_units, consumer_object)
+      internal_queue = strategy.instance_variable_get(:@queue)
+      expect(internal_queue).to be_a_kind_of(Array)
+      expect(internal_queue.first).to be_a_kind_of(Chore::UnitOfWork)
+      expect(internal_queue.first.id).to eq(msg)
+    end
+  end
+end

--- a/spec/chore/strategies/worker/helpers/ipc_spec.rb
+++ b/spec/chore/strategies/worker/helpers/ipc_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+require 'socket'
+
+describe Chore::Strategy::Ipc do
+  class DummyClass
+    include Chore::Strategy::Ipc
+  end
+
+  before(:each) do
+    @dummy_instance = DummyClass.new
+  end
+
+  let(:socket)          { double('socket') }
+  let(:connection)      { double('socket') }
+  let(:message)         { "test message" }
+  let(:encoded_message) { "#{[Marshal.dump(message).size].pack('L>')}#{Marshal.dump(message)}" }
+  let(:socket_base)     { './prefork_worker_sock-' }
+  let(:pid)             { '1' }
+  let(:socket_file)     { socket_base + pid }
+
+  describe '#create_master_socket' do
+    before(:each) do
+      allow(Process).to receive(:pid).and_return(pid)
+    end
+
+    it 'deletes socket file, if it already exists' do
+      allow(File).to receive(:exist?).with(socket_file).and_return(true)
+      allow(UNIXServer).to receive(:new).and_return(socket)
+      allow(socket).to receive(:setsockopt).and_return(true)
+      expect(File).to receive(:delete).with(socket_file)
+      @dummy_instance.create_master_socket
+    end
+
+    it 'should create and return a new UnixServer object' do
+      allow(File).to receive(:exist?).with(socket_file).and_return(false)
+      allow(UNIXServer).to receive(:new).and_return(socket)
+      allow(socket).to receive(:setsockopt).and_return(true)
+      expect(@dummy_instance.create_master_socket).to eq(socket)
+    end
+
+    it 'should set the required socket options' do
+      allow(File).to receive(:exist?).with(socket_file).and_return(false)
+      allow(UNIXServer).to receive(:new).and_return(socket)
+      expect(socket).to receive(:setsockopt).with(:SOCKET, :REUSEADDR, true)
+      @dummy_instance.create_master_socket
+    end
+  end
+
+  context '#child_connection' do
+    it 'should accept a connection and return the connection socket' do
+      expect(socket).to receive(:accept).and_return(connection)
+      expect(@dummy_instance.child_connection(socket)).to eq connection
+    end
+  end
+
+  context '#send_msg' do
+    it 'should raise an exception if the message is empty' do
+      expect { @dummy_instance.send_msg(socket, nil) }.to raise_error('send_msg cannot send empty messages')
+    end
+
+    it 'should send a message with the predefined protocol (size of message + marshalled message)' do
+      expect(socket).to receive(:send).with(encoded_message, 0)
+      @dummy_instance.send_msg(socket, message)
+    end
+  end
+
+  context '#read_msg' do
+    before(:each) do
+      allow(IO).to receive(:select).with([socket], nil, nil, 0.5).and_return([[socket], [], []])
+    end
+
+    it 'should return nil if the message size is missing' do
+      allow(socket).to receive(:recv).and_return(nil)
+      expect(@dummy_instance.read_msg(socket)).to eq(nil)
+    end
+
+    it 'should read a message with the predefined protocol (size of message + marshalled message)' do
+      allow(socket).to receive(:recv).and_return(encoded_message)
+      expect(@dummy_instance.read_msg(socket)).to eq(message)
+    end
+
+    it 'should raise an exception if the connection was dropped' do
+      allow(socket).to receive(:recv).and_raise(Errno::ECONNRESET)
+      expect { @dummy_instance.read_msg(socket) }.to raise_error(Errno::ECONNRESET)
+    end
+  end
+
+  context '#add_worker_socket' do
+    it 'should create and return a new UnixSocket object' do
+      allow(UNIXSocket).to receive(:new).and_return(socket)
+      allow(socket).to receive(:setsockopt).and_return(true)
+      expect(@dummy_instance.add_worker_socket).to eq(socket)
+    end
+
+    it 'should set the required socket options' do
+      allow(UNIXSocket).to receive(:new).and_return(socket)
+      expect(socket).to receive(:setsockopt).with(:SOCKET, :REUSEADDR, true)
+      @dummy_instance.add_worker_socket
+    end
+  end
+
+  context '#clear_ready' do
+    it 'should remove the ready signal from the the socket' do
+      expect(socket).to receive(:gets)
+      @dummy_instance.clear_ready(socket)
+    end
+  end
+
+  context '#signal_ready' do
+    it 'should set a ready signal on the socket' do
+      expect(socket).to receive(:puts).with('R')
+      @dummy_instance.signal_ready(socket)
+    end
+  end
+
+  context '#select_sockets' do
+    it 'should return a readable socket if one is found' do
+      allow(IO).to receive(:select).with([socket], nil, [socket], 0.5).and_return([[socket], [], []])
+      expect(@dummy_instance.select_sockets([socket], nil, 0.5)).to eq([[socket], [], []])
+    end
+
+    it 'should timeout and return no sockets if none are found within the timeout window' do
+      expect(@dummy_instance.select_sockets(nil, nil, 0.1)).to eq(nil)
+    end
+  end
+end
+

--- a/spec/chore/strategies/worker/helpers/preforked_worker_spec.rb
+++ b/spec/chore/strategies/worker/helpers/preforked_worker_spec.rb
@@ -1,0 +1,225 @@
+require 'spec_helper'
+
+describe Chore::Strategy::PreforkedWorker do
+  before(:each) do
+    allow_any_instance_of(Chore::Strategy::PreforkedWorker).to receive(:post_fork_setup)
+  end
+
+  let(:preforkedworker) { Chore::Strategy::PreforkedWorker.new }
+  let(:socket)          { double("socket") }
+  let(:work)            { double("work") }
+  let(:consumer)        { double("consumer") }
+  let(:worker)          { double("worker") }
+  let(:config)          { double("config") }
+  let(:queues)          { double("queues") }
+  let(:consumer_object) { double("consumer_object") }
+  let(:signals)         { { '1' => 'QUIT' } }
+
+  context '#start_worker' do
+    it 'should connect to the master to signal that it is ready, and process messages with the worker' do
+      allow(preforkedworker).to receive(:connect_to_master).and_return(socket)
+      expect(preforkedworker).to receive(:connect_to_master).with(socket)
+      allow(preforkedworker).to receive(:worker).and_return(true)
+      expect(preforkedworker).to receive(:worker).with(socket)
+      preforkedworker.start_worker(socket)
+    end
+  end
+
+  describe '#worker' do
+    before(:each) do
+      preforkedworker.instance_variable_set(:@self_read, socket)
+      allow(preforkedworker).to receive(:select_sockets).and_return([[socket],nil,nil])
+      allow(preforkedworker).to receive(:read_msg).and_return(nil)
+      allow(preforkedworker).to receive(:is_orphan?).and_return(false)
+      allow(preforkedworker).to receive(:process_work).and_return(true)
+      allow(preforkedworker).to receive(:signal_ready).and_return(true)
+      allow(work).to receive(:queue_timeout).and_return(20*60)
+    end
+
+
+    it 'should not run while @running is false' do
+      allow(preforkedworker).to receive(:running?).and_return(false)
+      expect(preforkedworker).to receive(:select_sockets).exactly(0).times
+      begin
+        preforkedworker.send(:worker, nil)
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+
+    it 'should be able to handle timeouts on readable sockets' do    
+       allow(preforkedworker).to receive(:running?).and_return(true, true, false)   
+       allow(preforkedworker).to receive(:select_sockets).and_return(nil)   
+       expect(preforkedworker).to receive(:select_sockets).exactly(2).times   
+       begin    
+         preforkedworker.send(:worker, nil)   
+       rescue SystemExit=>e   
+         expect(e.status).to eq(0)    
+       end    
+     end    
+
+    it 'should read a message if the connection is readable' do
+      allow(preforkedworker).to receive(:running?).and_return(true, false)
+      expect(preforkedworker).to receive(:read_msg).once
+      begin
+        preforkedworker.send(:worker, nil)
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+
+    it 'should check if the master is alive, and if not, it should end' do
+      allow(preforkedworker).to receive(:running).and_return(true)
+      allow(preforkedworker).to receive(:select_sockets).and_return([[socket],nil,nil])
+      allow(preforkedworker).to receive(:read_msg).and_return(nil)
+      allow(preforkedworker).to receive(:is_orphan?).and_return(true)
+      begin
+        preforkedworker.send(:worker, socket)
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+
+    it 'should process work if it is read from the master and signal ready' do
+      allow(preforkedworker).to receive(:running?).and_return(true, false)
+      allow(preforkedworker).to receive(:read_msg).and_return(work)
+      expect(preforkedworker).to receive(:process_work).once
+      expect(preforkedworker).to receive(:signal_ready).once
+      begin
+        preforkedworker.send(:worker, socket)
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+
+    it 'should exit the process if the connection to master is closed' do
+      allow(preforkedworker).to receive(:running?).and_return(true)
+      allow(preforkedworker).to receive(:read_msg).and_raise(Errno::ECONNRESET)
+      begin
+        preforkedworker.send(:worker, socket)
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+  end
+
+  context '#connect_to_master' do
+    it 'should create a connection to the master, and send it its PID and a ready message' do
+      allow(preforkedworker).to receive(:child_connection).and_return(socket)
+      allow(preforkedworker).to receive(:send_msg).and_return(true)
+      allow(preforkedworker).to receive(:signal_ready).and_return(true)
+
+      expect(preforkedworker).to receive(:child_connection).once
+      expect(preforkedworker).to receive(:send_msg).once
+      expect(preforkedworker).to receive(:signal_ready).once
+
+      res = preforkedworker.send(:connect_to_master,socket)
+
+      expect(res).to eq(socket)
+    end
+  end
+
+  context '#post_fork_setup' do
+    before(:each) do
+      allow(preforkedworker).to receive(:procline).and_return(true)
+      allow(preforkedworker).to receive(:trap_signals)
+      allow_any_instance_of(Chore::Strategy::PreforkedWorker).to receive(:post_fork_setup).and_call_original
+    end
+
+    it 'should change the process name' do
+      expect(preforkedworker).to receive(:procline)
+      preforkedworker.send(:post_fork_setup)
+    end
+
+    it 'should trap new relevant signals' do
+      expect(preforkedworker).to receive(:trap_signals)
+      preforkedworker.send(:post_fork_setup)
+    end
+  end
+
+  context '#process_work' do
+    before(:each) do
+      allow(preforkedworker).to receive(:consumer).and_return(consumer)
+      allow(work).to receive(:queue_name).and_return("test_queue")
+      allow(work).to receive(:consumer=)
+      allow(work).to receive(:queue_timeout).and_return(10)
+      allow(Chore::Worker).to receive(:new).and_return(worker)
+      allow(worker).to receive(:start)
+    end
+
+    it 'should fetch the consumer object associated with the queue' do
+      expect(preforkedworker).to receive(:consumer)
+      preforkedworker.send(:process_work, [work])
+    end
+
+    it 'should create and start a worker object with the job sent to it' do
+      expect(worker).to receive(:start)
+      preforkedworker.send(:process_work, [work])
+    end
+
+    it 'should timeout if the work runs for longer than the queue timeout' do
+      allow(work).to receive(:queue_timeout).and_return(1)
+      allow(worker).to receive(:start) { sleep 5 }
+      begin
+        preforkedworker.send(:process_work, [work])
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+  end
+
+  context '#consumer' do
+    before(:each) do
+      preforkedworker.instance_variable_set(:@consumer_cache, {key_1: :value_1})
+      allow(Chore).to receive(:config).and_return(config)
+      allow(config).to receive(:queues).and_return(queues)
+      allow(queues).to receive(:size).and_return(2)
+      allow(config).to receive(:consumer).and_return(consumer)
+      allow(consumer).to receive(:new).and_return(:value_2)
+    end
+
+    it 'should fetch a consumer object if it was created previously for this queue' do
+      preforkedworker.instance_variable_set(:@consumer_cache, {key_1: :value_1})
+      res = preforkedworker.send(:consumer,:key_1)
+      expect(res).to eq(:value_1)
+    end
+
+    it 'should create and return a new consumer object if one does not exist for this queue' do
+      preforkedworker.instance_variable_set(:@consumer_cache, {})
+      expect(consumer).to receive(:new)
+      res = preforkedworker.send(:consumer,:key_2)
+      expect(res).to eq(:value_2)
+    end
+  end
+
+  context '#trap_signals' do
+    it 'should reset signals' do
+      allow(Chore::Signal).to receive(:reset)
+      expect(Chore::Signal).to receive(:reset)
+      preforkedworker.send(:trap_signals, {})
+    end
+
+    it 'should trap the signals passed to it' do
+      allow(Chore::Signal).to receive(:reset)
+      expect(Chore::Signal).to receive(:trap).with('QUIT').once
+      preforkedworker.send(:trap_signals, signals)
+    end
+  end
+
+  context '#is_orphan?' do
+    it 'should return true if the parent is dead' do
+      allow(Process).to receive(:ppid).and_return(10)
+      preforkedworker.instance_variable_set(:@manager_pid, 9)
+      res = preforkedworker.send(:is_orphan?)
+      expect(res).to eq(true)
+    end
+
+    it 'should return false if the parent is alive' do
+      allow(Process).to receive(:ppid).and_return(10)
+      preforkedworker.instance_variable_set(:@manager_pid, 10)
+      res = preforkedworker.send(:is_orphan?)
+      expect(res).to eq(false)
+    end
+  end
+end
+

--- a/spec/chore/strategies/worker/helpers/work_distributor_spec.rb
+++ b/spec/chore/strategies/worker/helpers/work_distributor_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require 'chore/strategies/worker/helpers/work_distributor'
+
+describe Chore::Strategy::WorkDistributor do
+  let(:timestamp) { Time.now }
+  let(:manager) { double('manager') }
+  let(:worker) { Chore::Strategy::WorkerInfo.new(1) }
+  let(:consumer) { double('consumer') }
+  let(:job) do
+    Chore::UnitOfWork.new(
+      SecureRandom.uuid,
+      'test',
+      60,
+      Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])),
+      0
+    )
+  end
+  let(:socket) { double('socket') }
+
+  context '#include_ipc' do
+    it 'should include the Ipc module' do
+      expect(described_class.ipc_help).to eq(:available)
+    end
+  end
+
+  context '#fetch_and_assign_jobs' do
+    it 'should fetch jobs from the consumer' do
+      allow(described_class).to receive(:assign_jobs).and_return(true)
+      allow(manager).to receive(:fetch_work).with(1).and_return([job])
+      expect(manager).to receive(:fetch_work).with(1)
+      described_class.fetch_and_assign_jobs([worker], manager)
+    end
+
+    it 'should assign the fetched jobs to the workers' do
+      allow(manager).to receive(:fetch_work).with(1).and_return([job])
+      expect(described_class).to receive(:assign_jobs).with([job], [worker])
+      described_class.fetch_and_assign_jobs([worker], manager)
+    end
+
+    it 'should raise and exception if it does not get an array from the manager' do
+      allow(manager).to receive(:fetch_work).with(1).and_return(nil)
+      expect { described_class.fetch_and_assign_jobs([worker], manager) }.to raise_error("DW: jobs needs to be a list got NilClass")
+    end
+
+    it 'should sleep if no jobs are available' do
+      expect(described_class).to receive(:sleep).with(0.1)
+      allow(manager).to receive(:fetch_work).with(1).and_return([])
+      described_class.fetch_and_assign_jobs([worker], manager)
+    end
+  end
+
+  context '#assign_jobs' do
+    it 'should raise an exception if we have no free workers' do
+      expect { described_class.send(:assign_jobs, [job], []) }.to raise_error('DW: assign_jobs got 0 workers')
+    end
+
+    it 'should remove the consumer object from the job object' do
+      allow(described_class).to receive(:push_job_to_worker).and_return(true)
+
+      described_class.send(:assign_jobs, [job], [worker])
+    end
+
+    it 'should raise an exception if more jobs than workers are provided to it' do
+      allow(described_class).to receive(:push_job_to_worker).and_return(true)
+
+      expect { described_class.send(:assign_jobs, [job, job], [worker]) }.to raise_error('DW: More Jobs than Sockets')
+    end
+
+    it 'should send the job object to the free worker' do
+      allow(described_class).to receive(:push_job_to_worker).and_return(true)
+
+      expect(described_class).to receive(:push_job_to_worker).with(job, worker)
+      described_class.send(:assign_jobs, [job], [worker])
+    end
+  end
+
+  context '#push_job_to_worker' do
+    before(:each) do
+      allow(described_class).to receive(:clear_ready).with(worker.socket).and_return(true)
+      allow(described_class).to receive(:send_msg).with(worker.socket, job).and_return(true)
+    end
+
+    it 'should clear all signals from the worker' do
+      expect(described_class).to receive(:clear_ready).with(worker.socket)
+      described_class.send(:push_job_to_worker, job, worker)
+    end
+
+    it 'should send the job as a message on the worker' do
+      expect(described_class).to receive(:send_msg).with(worker.socket, job)
+      described_class.send(:push_job_to_worker, job, worker)
+    end
+  end
+end

--- a/spec/chore/strategies/worker/helpers/worker_info_spec.rb
+++ b/spec/chore/strategies/worker/helpers/worker_info_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Chore::Strategy::WorkerInfo do
+  let(:pid)         { 1 }
+  let(:worker_info) { Chore::Strategy::WorkerInfo.new(pid) }
+
+  context '#initialize' do
+    it 'should initialize the WorkerInfo with a pid' do
+      wi = Chore::Strategy::WorkerInfo.new(pid)
+      expect(wi.pid).to equal(pid)
+      expect(wi.socket).to equal(nil)
+    end
+  end
+end

--- a/spec/chore/strategies/worker/helpers/worker_killer_spec.rb
+++ b/spec/chore/strategies/worker/helpers/worker_killer_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require 'get_process_mem'
+
+describe Chore::Strategy::WorkerKiller do
+  let(:memory_limit)    { 1024 }
+  let(:request_limit)   { 100 }
+  let(:check_cycle)     { 16 }
+  let(:worker_killer)   { Chore::Strategy::WorkerKiller.new }
+  let(:process_mem_obj) { double('process_mem_obj', bytes: 10) }
+
+  context '#initialize' do
+    it 'should initialize the WorkerKiller correctly' do
+      allow(Chore.config).to receive(:memory_limit_bytes).and_return(memory_limit)
+      allow(Chore.config).to receive(:request_limit).and_return(request_limit)
+      allow(Chore.config).to receive(:check_cycle).and_return(check_cycle)
+
+      wk = Chore::Strategy::WorkerKiller.new
+      expect(wk.instance_variable_get(:@memory_limit)).to equal(memory_limit)
+      expect(wk.instance_variable_get(:@request_limit)).to equal(request_limit)
+      expect(wk.instance_variable_get(:@check_cycle)).to equal(check_cycle)
+      expect(wk.instance_variable_get(:@check_count)).to equal(0)
+      expect(wk.instance_variable_get(:@current_requests)).to equal(0)
+    end
+  end
+
+  context '#check_memory' do
+    before(:each) do
+      allow(GetProcessMem).to receive(:new).and_return(process_mem_obj)
+      worker_killer.instance_variable_set(:@memory_limit, memory_limit)
+      worker_killer.instance_variable_set(:@check_cycle, check_cycle)
+    end
+
+    it 'should return nil when memory_limit is nil' do
+      worker_killer.instance_variable_set(:@memory_limit, nil)
+      expect(worker_killer.check_memory).to eq(nil)
+    end
+
+    it 'should increment the check count by 1' do
+      worker_killer.instance_variable_set(:@check_count, 1)
+      worker_killer.check_memory
+      expect(worker_killer.instance_variable_get(:@check_count)).to eq(2)
+    end
+
+    context 'check_count equals check_cycle' do
+      before(:each) do
+        worker_killer.instance_variable_set(:@check_count, 15)
+      end
+
+      it 'should check memory' do
+        expect(process_mem_obj).to receive(:bytes)
+        worker_killer.check_memory
+      end
+
+      it 'should reset the check_count to zero' do
+        allow(process_mem_obj).to receive(:bytes).and_return(0)
+        worker_killer.check_memory
+        expect(worker_killer.instance_variable_get(:@check_count)).to equal(0)
+      end
+
+      it 'should exit if the process mem exceeds the memory_limit' do
+        allow(process_mem_obj).to receive(:bytes).and_return(2048)
+        begin
+          worker_killer.check_memory
+        rescue SystemExit=>e
+          expect(e.status).to eq(0)
+        end
+      end
+    end
+  end
+
+  context '#check_requests' do
+    before(:each) do
+      worker_killer.instance_variable_set(:@request_limit, request_limit)
+      worker_killer.instance_variable_set(:@current_requests, 0)
+    end
+
+    it 'should return nil when request_limit is nil' do
+      worker_killer.instance_variable_set(:@request_limit, nil)
+      expect(worker_killer.check_requests).to eq(nil)
+    end
+
+    it 'should increment current requests' do
+      worker_killer.check_requests
+      expect(worker_killer.instance_variable_get(:@current_requests)).to eq(1)
+    end
+
+    it 'should exit when current_requests exceeds request_limit' do
+      worker_killer.instance_variable_set(:@current_requests, request_limit - 1)
+
+      begin
+        worker_killer.check_requests
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/chore/strategies/worker/helpers/worker_manager_spec.rb
+++ b/spec/chore/strategies/worker/helpers/worker_manager_spec.rb
@@ -1,0 +1,297 @@
+require 'spec_helper'
+require 'chore/signal'
+require 'chore/strategies/worker/helpers/worker_manager'
+
+describe Chore::Strategy::WorkerManager do
+  let(:master_socket) { double('master_socket') }
+
+  let(:worker_manager) { Chore::Strategy::WorkerManager.new(master_socket) }
+
+
+  let(:worker_pid_1) { 1 }
+  let(:socket_1) { double('socket_1') }
+
+  let(:worker_pid_2) { 2 }
+  let(:socket_2) { double('socket_2') }
+
+  let(:worker_pid_3) { 3 }
+
+  let(:pid_sock_hash) { { worker_pid_1 => socket_1,
+                          worker_pid_2 => socket_2 } }
+  let(:pid_sock_hash_2) { { worker_pid_1 => socket_1 } }
+
+  let(:pid_sock_hash_3) { { worker_pid_1 => socket_1,
+                          worker_pid_2 => socket_2,
+                          worker_pid_3 => nil } }
+
+  let(:config) { double("config") }
+  let(:worker) { double("worker") }
+
+  let(:worker_info_1) { double('worker_info_1') }
+  let(:worker_info_2) { double('worker_info_2') }
+
+  let(:pid_to_worker) { {
+                          worker_pid_1 => worker_info_1,
+                          worker_pid_2 => worker_info_2
+                      } }
+  let(:socket_to_worker) { {
+                          socket_1 => worker_info_1,
+                          socket_2 => worker_info_2
+                      } }
+
+  context '#include_ipc' do
+    it 'should include the Ipc module' do
+      expect(worker_manager.ipc_help).to eq(:available)
+    end
+  end
+
+  context '#create_and_attach_workers' do
+    before(:each) do
+      allow(worker_manager).to receive(:create_workers).and_yield(2)
+      allow(worker_manager).to receive(:attach_workers).and_return(true)
+    end
+
+    it 'should call to create replacement workers' do
+      expect(worker_manager).to receive(:create_workers)
+      worker_manager.create_and_attach_workers
+    end
+
+    it 'should create a map between new workers to new sockets' do
+      expect(worker_manager).to receive(:attach_workers).with(2)
+      worker_manager.create_and_attach_workers
+    end
+  end
+
+  context '#respawn_terminated_workers!' do
+    before(:each) do
+      allow(worker_manager).to receive(:create_and_attach_workers).and_return(true)
+      allow(worker_manager).to receive(:reap_workers).and_return(true)
+    end
+
+    it 'should reap all the terminated worker processes' do
+      expect(worker_manager).to receive(:reap_workers)
+      worker_manager.respawn_terminated_workers!
+    end
+
+    it 'should re-create and attach all the workers that died' do
+      expect(worker_manager).to receive(:create_and_attach_workers)
+      worker_manager.respawn_terminated_workers!
+    end
+  end
+
+  context '#stop_workers' do
+    let(:signal) { 'TERM' }
+    before(:each) do
+      allow(Process).to receive(:kill).and_return(nil)
+      allow(worker_manager).to receive(:reap_workers)
+      worker_manager.instance_variable_set(:@pid_to_worker, pid_sock_hash)
+    end
+
+    it 'should forward the signal received to each of the child processes' do
+      pid_sock_hash.each do |pid, sock|
+        expect(Process).to receive(:kill).with(signal, pid)
+      end
+      worker_manager.stop_workers(signal)
+    end
+
+    it 'should reap all terminated child processes' do
+      expect(worker_manager).to receive(:reap_workers)
+      worker_manager.stop_workers(signal)
+    end
+  end
+
+  context 'worker_sockets' do
+    it 'should return a list of socket assoicated with workers' do
+      worker_manager.instance_variable_set(:@socket_to_worker, socket_to_worker)
+      res = worker_manager.worker_sockets
+      expect(res).to eq([socket_1, socket_2])
+    end
+  end
+
+  context '#ready_workers' do
+    it 'should return a list of workers assoicated with given sockets' do
+      worker_manager.instance_variable_set(:@socket_to_worker, socket_to_worker)
+      allow(worker_info_1).to receive(:reset_start_time!)
+      res = worker_manager.ready_workers([socket_1])
+      expect(res).to eq([worker_info_1])
+    end
+
+    it 'should yield when a block is passed to it' do
+      worker_manager.instance_variable_set(:@socket_to_worker, socket_to_worker)
+      allow(worker_info_1).to receive(:reset_start_time!)
+      expect{ |b| worker_manager.ready_workers([socket_1], &b) }.to yield_control
+    end
+  end
+
+  context '#create_workers' do
+    before(:each) do
+      allow(worker_manager).to receive(:fork).and_yield
+      allow(worker_manager).to receive(:run_worker_instance)
+      allow(Chore).to receive(:config).and_return(config)
+    end
+
+    it 'should fork it running process till we have the right optimized number of workers and return the number of workers it created' do
+      allow(config).to receive(:num_workers).and_return(1)
+      expect(worker_manager).to receive(:fork).once
+      expect(worker_manager).to receive(:run_worker_instance).once
+      worker_manager.send(:create_workers)
+    end
+
+    it 'should raise an exception if an inconsistent number of workers are created' do
+      allow(config).to receive(:num_workers).and_return(0)
+      allow(worker_manager).to receive(:inconsistent_worker_number).and_return(true)
+      expect(worker_manager).to receive(:inconsistent_worker_number)
+      expect { worker_manager.send(:create_workers) }.to raise_error(RuntimeError)
+    end
+
+    it 'should call the block passed to it with the number of workers it created' do
+      allow(config).to receive(:num_workers).and_return(0)
+      allow(worker_manager).to receive(:inconsistent_worker_number).and_return(false)
+      expect { |b| worker_manager.send(:create_workers, &b) }.to yield_control.once
+    end
+  end
+
+  context '#inconsistent_worker_number' do
+    it 'should check if the worker numbers match the number configured' do
+      allow(Chore).to receive(:config).and_return(config)
+      allow(config).to receive(:num_workers).and_return(2)
+      worker_manager.instance_variable_set(:@pid_to_worker, pid_to_worker)
+      res_false = worker_manager.send(:inconsistent_worker_number)
+      allow(config).to receive(:num_workers).and_return(4)
+      res_true = worker_manager.send(:inconsistent_worker_number)
+      expect(res_true).to be(true)
+      expect(res_false).to be(false)
+    end
+  end
+
+  context '#run_worker_instance' do
+    before(:each) do
+      allow(Chore::Strategy::PreforkedWorker).to receive(:new).and_return(worker)
+      allow(worker).to receive(:start_worker).and_return(true)
+      allow(worker_manager).to receive(:exit!).and_return(true)
+    end
+
+    it 'should create a PreforkedWorker object and start it' do
+      expect(Chore::Strategy::PreforkedWorker).to receive(:new).and_return(worker)
+      expect(worker).to receive(:start_worker)
+      worker_manager.send(:run_worker_instance)
+    end
+
+    it 'should ensure that the process exits when the PreforkedWorker completes' do
+      expect(worker_manager).to receive(:exit!).with(true)
+      worker_manager.send(:run_worker_instance)
+    end
+  end
+
+  context '#attach_workers' do
+    before(:each) do
+      allow(worker_manager).to receive(:create_worker_sockets).and_return([socket_1, socket_2])
+      allow(worker_manager).to receive(:read_msg).and_return(worker_pid_1, worker_pid_2)
+      allow(worker_manager).to receive(:kill_unattached_workers).and_return(true)
+      worker_manager.instance_variable_set(:@pid_to_worker, pid_to_worker)
+      worker_manager.instance_variable_set(:@socket_to_worker, {})
+      allow(worker_info_1).to receive(:socket=)
+      allow(worker_info_2).to receive(:socket=)
+      allow(worker_manager).to receive(:select_sockets).and_return([[socket_1], [], []], [[socket_2], [], []])
+    end
+
+    it 'should add as many sockets as the number passed to it as a param' do
+      expect(worker_manager).to receive(:read_msg).twice
+      worker_manager.send(:attach_workers, 2)
+    end
+
+    it 'should select on each socket to make sure its readable' do
+      expect(worker_manager).to receive(:select_sockets).twice
+      worker_manager.send(:attach_workers, 2)
+    end
+
+    it 'should get the PID from each socket it creates and map that to the worker that it is connected to' do
+      worker_manager.send(:attach_workers, 2)
+      expect(worker_manager.instance_variable_get(:@socket_to_worker)).to eq(socket_to_worker)
+    end
+
+    it 'should kill any unattached workers' do
+      expect(worker_manager).to receive(:kill_unattached_workers)
+      worker_manager.send(:attach_workers, 2)
+    end
+
+    it 'should close sockets that failed to get a connection by timing out' do
+      allow(worker_manager).to receive(:select_sockets).and_return([[socket_1], [], []], [nil, nil, nil])
+      expect(socket_1).not_to receive(:close)
+      expect(socket_2).to receive(:close)
+      worker_manager.send(:attach_workers, 2)
+    end
+
+    it 'should close sockets that failed to get a connection by econnreset' do
+      allow(worker_manager).to receive(:select_sockets).with(socket_1, nil, 2).and_return([[socket_1], [], []])
+      allow(worker_manager).to receive(:select_sockets).with(socket_2, nil, 2).and_raise(Errno::ECONNRESET)
+      expect(socket_1).not_to receive(:close)
+      expect(socket_2).to receive(:close)
+      worker_manager.send(:attach_workers, 2)
+    end
+  end
+
+  context "#create_worker_sockets" do
+    it 'should return an array of sockets equal to the number passed to it' do
+      allow(worker_manager).to receive(:add_worker_socket).and_return(socket_1, socket_2, socket_2, socket_1)
+      num = 3
+      res = worker_manager.send(:create_worker_sockets, num)
+      expect(res.size).to eq(num)
+    end
+  end
+
+  context "#kill_unattached_workers" do
+    it 'should send a kill -9 to PIDs that do not have a socket attached to them' do
+      worker_manager.instance_variable_set(:@pid_to_worker, pid_to_worker)
+      allow(worker_info_1).to receive(:socket).and_return(socket_1)
+      allow(worker_info_2).to receive(:socket).and_return(nil)
+      allow(Process).to receive(:kill).and_return(true)
+      expect(Process).to receive(:kill).with('KILL', worker_pid_2).once
+      worker_manager.send(:kill_unattached_workers)
+    end
+  end
+
+  context "#reap_workers" do
+    before(:each) do
+      worker_manager.instance_variable_set(:@pid_to_worker, pid_to_worker)
+      allow(worker_info_1).to receive(:socket).and_return(socket_1)
+      allow(worker_info_1).to receive(:pid).and_return(worker_pid_1)
+      allow(worker_info_2).to receive(:socket).and_return(socket_2)
+      allow(worker_info_2).to receive(:pid).and_return(worker_pid_2)
+    end
+
+    it 'should run through each worker-pid map and delete the worker pids from the hash, if they were dead' do
+      allow(worker_manager).to receive(:reap_process).and_return(false, true)
+      expect(worker_manager.instance_variable_get(:@pid_to_worker).size).to eq(2)
+      worker_manager.send(:reap_workers)
+      expect(worker_manager.instance_variable_get(:@pid_to_worker).size).to eq(1)
+    end
+
+    it 'should not change the worker pids map, if all the childern are running' do
+      allow(worker_manager).to receive(:reap_process).and_return(false, false)
+      expect(worker_manager.instance_variable_get(:@pid_to_worker).size).to eq(2)
+      worker_manager.send(:reap_workers)
+      expect(worker_manager.instance_variable_get(:@pid_to_worker).size).to eq(2)
+    end
+  end
+
+  context "#reap_worker" do
+    it 'should return true if the pid was dead' do
+      allow(Process).to receive(:wait).and_return(worker_pid_1)
+      res = worker_manager.send(:reap_process, worker_pid_1)
+      expect(res).to eq(true)
+    end
+
+    it 'should return false if the pid was running' do
+      allow(Process).to receive(:wait).and_return(nil)
+      res = worker_manager.send(:reap_process, worker_pid_1)
+      expect(res).to eq(false)
+    end
+
+    it 'should return true if the pid was dead' do
+     allow(Process).to receive(:wait).and_raise(Errno::ECHILD)
+     res = worker_manager.send(:reap_process, worker_pid_1)
+     expect(res).to eq(true)
+   end
+ end
+end

--- a/spec/chore/strategies/worker/preforked_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/preforked_worker_strategy_spec.rb
@@ -1,0 +1,163 @@
+require 'spec_helper'
+
+describe Chore::Strategy::PreForkedWorkerStrategy do
+
+  let(:manager) { double('manager')  }
+  let(:socket) { double("socket") }
+  let(:pipe) { double("pipe") }
+  let(:worker) { double('worker') }
+  let(:worker_manager) { Chore::Strategy::WorkerManager.new(socket) }
+  let(:strategy) { Chore::Strategy::PreForkedWorkerStrategy.new(manager)}
+  let(:work_distributor) { Chore::Strategy::WorkDistributor }
+
+  before(:each) do
+    allow_any_instance_of(Chore::Strategy::PreForkedWorkerStrategy).to receive(:trap_signals).and_return(true)
+    strategy.instance_variable_set(:@worker_manager, worker_manager)
+  end
+
+  context '#start' do
+    it 'should create, attach workers and start the worker manager' do
+      allow(worker_manager).to receive(:create_and_attach_workers)
+      allow(strategy).to receive(:worker_assignment_thread).and_return(true)
+
+      expect(worker_manager).to receive(:create_and_attach_workers)
+      expect(strategy).to receive(:worker_assignment_thread)
+      strategy.start
+    end
+  end
+
+  context '#stop!' do
+    it 'should set the system\'s running state to false' do
+      strategy.instance_variable_set(:@running, true)
+      strategy.stop!
+      expect(strategy.instance_variable_get(:@running)).to eq false
+    end
+  end
+
+  context '#worker_assignment_thread' do
+    before(:each) do
+      allow(Thread).to receive(:new).and_return(true)
+    end
+
+    it 'create a new thread with the worker_assignment_loop' do
+      allow(strategy).to receive(:worker_assignment_loop).and_return(true)
+      expect(Thread).to receive(:new).once.and_yield
+      expect(strategy).to receive(:worker_assignment_loop)
+      strategy.send(:worker_assignment_thread)
+    end
+
+    it 'rescues a \'TerribleMistake\' exception and performs a shutdown of chore' do
+      allow(strategy).to receive(:worker_assignment_loop).and_raise(Chore::TerribleMistake)
+      allow(Thread).to receive(:new).and_yield
+      allow(manager).to receive(:shutdown!).and_return(true)
+      expect(manager).to receive(:shutdown!)
+      strategy.send(:worker_assignment_thread)
+    end
+  end
+
+  context '#worker_assignment_loop' do
+    before(:each) do
+      allow(strategy).to receive(:running?).and_return(true, false)
+      strategy.instance_variable_set(:@self_read, pipe)
+      allow(strategy).to receive(:select_sockets).and_return([[socket],nil, nil])
+      allow(strategy).to receive(:handle_self_pipe_signal).and_return(true)
+      allow(strategy).to receive(:fetch_and_assign_jobs).and_return(true)
+
+      allow(worker_manager).to receive(:worker_sockets).and_return([socket])
+      allow(worker_manager).to receive(:ready_workers).and_yield([worker])
+      allow(worker_manager).to receive(:destroy_expired!)
+
+      allow(work_distributor).to receive(:fetch_and_assign_jobs)
+    end
+
+    it 'should terminate when @running is set to false' do
+      allow(strategy).to receive(:running?).and_return(false)
+      expect(strategy).to receive(:select_sockets).exactly(0).times
+      strategy.send(:worker_assignment_loop)
+    end
+
+    it 'should get the worker_sockets' do
+      expect(worker_manager).to receive(:worker_sockets)
+      strategy.send(:worker_assignment_loop)
+    end
+
+    it 'should handle no sockets being ready' do
+      allow(strategy).to receive(:select_sockets).and_return(nil)
+      expect(strategy).to receive(:select_sockets).once
+      strategy.send(:worker_assignment_loop)
+    end
+
+    it 'should handle signals if alerted on a self pipe' do
+      allow(strategy).to receive(:select_sockets).and_return([[pipe], nil, nil])
+      expect(strategy).to receive(:handle_signal).once
+      strategy.send(:worker_assignment_loop)
+    end
+
+    it 'should handle fetch and assign jobs when workers are ready' do
+      expect(work_distributor).to receive(:fetch_and_assign_jobs).with([worker], manager).once
+      strategy.send(:worker_assignment_loop)
+    end
+  end
+
+  context '#handle_signal' do
+    before(:each) do
+      strategy.instance_variable_set(:@self_read, pipe)
+      allow(pipe).to receive(:read_nonblock).and_return(nil)
+
+      allow(worker_manager).to receive(:respawn_terminated_workers!).and_return(true)
+      allow(worker_manager).to receive(:stop_workers).and_return(true)
+      allow(manager).to receive(:shutdown!).and_return(true)
+    end
+
+    it 'should respawn terminated workers in the event of a SIGCHLD' do
+      allow(pipe).to receive(:read_nonblock).and_return('1')
+      expect(worker_manager).to receive(:respawn_terminated_workers!).once
+
+      strategy.send(:handle_signal)
+    end
+
+    it 'should signal its children, and shutdown in the event of one of INT, QUIT or TERM signals' do
+      allow(pipe).to receive(:read_nonblock).and_return('2','3','4')
+      expect(worker_manager).to receive(:stop_workers).exactly(3).times
+      expect(manager).to receive(:shutdown!).exactly(3).times
+      3.times do
+        strategy.send(:handle_signal)
+      end
+    end
+
+    it 'should propagte the signal it receives to its children' do
+      allow(pipe).to receive(:read_nonblock).and_return('3')
+      expect(worker_manager).to receive(:stop_workers).with(:QUIT)
+      strategy.send(:handle_signal)
+    end
+
+    it 'should not preform any task when an unhandled signal is called' do
+      allow(pipe).to receive(:read_nonblock).and_return('9')
+      expect(worker_manager).to receive(:respawn_terminated_workers!).exactly(0).times
+      expect(worker_manager).to receive(:stop_workers).exactly(0).times
+      expect(manager).to receive(:shutdown!).exactly(0).times
+      strategy.send(:handle_signal)
+    end
+  end
+
+  context '#trap_signals' do
+    before(:each) do
+      allow_any_instance_of(Chore::Strategy::PreForkedWorkerStrategy).to receive(:trap_signals).and_call_original
+    end
+
+    let(:signals) { { '1' => 'QUIT' } }
+        
+    it 'should reset signals' do
+      allow(Chore::Signal).to receive(:reset)
+      expect(Chore::Signal).to receive(:reset)
+      strategy.send(:trap_signals, {}, pipe)
+    end
+
+    it 'should trap the signals passed to it' do
+      allow(Chore::Signal).to receive(:reset)
+      expect(Chore::Signal).to receive(:trap).with('QUIT').once
+      strategy.send(:trap_signals, signals, pipe)
+    end
+  end
+end
+


### PR DESCRIPTION
Objective
==
The main objective of the changes in this PR is to reduce job latencies on chore. We define latency on chore, as the time duration from when the message is consumed from a source, to when it is completed by a worker. The metric that we use to measure the latency is the average job latency per second. 

We aim to meet this objective with the introduction of these two strategies: 

- Pre-Forked worker strategy
- Throttled consumer strategy

Pre-Forked worker strategy: 
--
The goals of the pre-forked worker strategy are:
 - Manage the lifecycle of a group of workers. 
 - Manage job assignments to workers to minimize latency

Throttled consumer:
--
The goals of the throttled consumer strategy are:
 - Minimize the jobs in the chore which are in-flight but not being worked on. 
 - Always keep the internal pipeline of jobs full.

Tests and observations:
--
To test the effectiveness of the changes in the PR, we used this test job:
```
def perform(*args)
    sleep(1)
    5000.times{ |i| Digest::MD5.hexdigest(JSON.generate({ i => args})) }
end
```

We set up 2 servers to execute chore, one running the pre-forked worker strategy with the throttled consumers strategy and the other one running the forked worker strategy and with the threaded consumer.  The chore instances were running on Ruby 2.3.0 (MRI)

The configurations for both cases were: 
```
c.publisher           = Chore::Queues::SQS::Publisher
c.consumer            = Chore::Queues::SQS::Consumer

# note: batch_size only relevant for the threaded consumer strategy
c.batch_size          = 10
c.threads_per_queue   = 2
c.dedupe_servers      = 'localhost:11211'

c.num_workers         = 10
c.max_attempts        = 1000
c.default_queue_timeout = 60

c.queue_polling_size  = 10
```

Over a 1 hour run, this we measured the average latency of each job that was processed. We observed that the average latency was consistently, and considerably lower in the new case of the the new strategies. 
![Comparing latency](https://cloud.githubusercontent.com/assets/615316/14549250/140cae74-0273-11e6-967a-1cdb9ce8a75f.png)

In addition to measuring latency, we also measured the throughput (i.e. total number of jobs completed per second). While our primary objective was to reduce latency, we wanted to ensure that we would not affect the throughput in any drastic way. Our observation shows that the throughput over a 1 hour window is more or less similar between the two sets of strategies. 
![Comparing Throughput](https://cloud.githubusercontent.com/assets/615316/14549279/45e35c0e-0273-11e6-89ab-7ed32f90bf5d.png)

The memory consumption was also measured across the two servers over a one hour period. This is the memory used on the server running the preforked worker strategy:
![Preforked worker memory used](https://cloud.githubusercontent.com/assets/615316/14549290/5e716202-0273-11e6-9eaa-5f33b124a311.png)

This is the memory used on the server running the forked worker strategy:
![Forked worker memory used](https://cloud.githubusercontent.com/assets/615316/14549292/6300ba7a-0273-11e6-8aff-9e458ba1c2bd.png)


Additional constraints:
--
The only constraint imposed is that, the pre-forked worker strategy and throttled consumer strategy can only be used with each other; They are not intended to be used with any other worker or consumer strategies.


Please review: @StabbyCutyou @surendrapathak @obrie @Ceraunograph @theo-lanman @andyleclair @marcuswalser @riteshnoronha @alvindu @pravinchandruTapjoy 