### PR TITLE
add exception logging to help debugging

### DIFF
--- a/lib/chore/strategies/worker/helpers/work_distributor.rb
+++ b/lib/chore/strategies/worker/helpers/work_distributor.rb
@@ -36,7 +36,7 @@ module Chore
           clear_ready(worker.socket)
           send_msg(worker.socket, job)
         rescue => e
-          Chore.logger.error "DW: Could not assign job #{job.inspect}"
+          Chore.logger.error "DW: Could not assign job #{job.inspect}\nException #{e.message} #{e.backtrace * "\n"}"
         end
 
         private


### PR DESCRIPTION
@Tapjoy/tools @riteshnoronha @goose42 @Ceraunograph 

When trying to debug why some clicks where not being processed in Otto, I noticed that the WorkDistributor was swallowing exceptions and not providing any logging. This made debugging very difficult. Let's add some exception info.