### PR TITLE
Memoize hook lookups to reduce performance impact when processing large numbers of jobs

### DIFF
--- a/lib/chore/hooks.rb
+++ b/lib/chore/hooks.rb
@@ -15,7 +15,8 @@ module Chore
 
   private
     def hooks_for(event)
-      candidate_methods.grep(/^#{event}/).sort
+      @_chore_hooks ||= {}
+      @_chore_hooks[event] ||= candidate_methods.grep(/^#{event}/).sort
     end
 
     # NOTE: Any hook methods defined after this is first referenced (i.e.,


### PR DESCRIPTION
This memoizes the candidate lookup for hooks so that we only do the search once per class.  Without this, there's a pretty significant amount of overhead when processing very small, very fast jobs at a large scale.

/to @Tapjoy/dmmeas 