### PR TITLE
Various filesystem consumer improvements

### DIFF
--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -41,6 +41,7 @@ module Chore #:nodoc:
     :shutdown_timeout      => (2 * 60),
     :max_attempts          => 1.0 / 0.0, # Infinity
     :dupe_on_cache_failure => false,
+    :queue_polling_size    => 10,
     :payload_handler       => Chore::Job,
     :master_procline       => "chore-master-#{Chore::VERSION}",
     :worker_procline       => "chore-worker-#{Chore::VERSION}",

--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -43,7 +43,8 @@ module Chore #:nodoc:
     :dupe_on_cache_failure => false,
     :payload_handler       => Chore::Job,
     :master_procline       => "chore-master-#{Chore::VERSION}",
-    :worker_procline       => "chore-worker-#{Chore::VERSION}"
+    :worker_procline       => "chore-worker-#{Chore::VERSION}",
+    :consumer_sleep_interval => 1
   }
 
   class << self

--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -144,6 +144,8 @@ module Chore #:nodoc:
       register_option 'shutdown_timeout', '--shutdown-timeout SECONDS', Float, "Upon shutdown, the number of seconds to wait before force killing worker strategies (default: #{Chore::DEFAULT_OPTIONS[:shutdown_timeout]})"
 
       register_option 'dupe_on_cache_failure', '--dupe-on-cache-failure BOOLEAN', 'Determines the deduping behavior when a cache connection error occurs. When set to false, the message is assumed not to be a duplicate. (default: false)'
+
+      register_option 'queue_polling_size', '--queue_polling_size NUM', Integer, 'Amount of messages to grab on each request (default: 10)'
     end
 
     def parse_opts(argv, ignore_errors = false) #:nodoc:

--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -135,7 +135,7 @@ module Chore #:nodoc:
         options[:consumer_strategy] = constantize(arg)
       end
 
-      register_option 'consumer_sleep_interval', '--consumer-sleep-interval INTERVAL', Float, 'Length of time in seconds to sleep when the consumer does not find any messages. Defaults vary depending on consumer implementation'
+      register_option 'consumer_sleep_interval', '--consumer-sleep-interval INTERVAL', Float, 'Length of time in seconds to sleep when the consumer does not find any messages (default: 1)'
 
       register_option 'payload_handler', '--payload_handler CLASS_NAME', 'Name of a class to use as the payload handler (default: Chore::Job)' do |arg|
         options[:payload_handler] = constantize(arg)
@@ -144,7 +144,6 @@ module Chore #:nodoc:
       register_option 'shutdown_timeout', '--shutdown-timeout SECONDS', Float, "Upon shutdown, the number of seconds to wait before force killing worker strategies (default: #{Chore::DEFAULT_OPTIONS[:shutdown_timeout]})"
 
       register_option 'dupe_on_cache_failure', '--dupe-on-cache-failure BOOLEAN', 'Determines the deduping behavior when a cache connection error occurs. When set to false, the message is assumed not to be a duplicate. (default: false)'
-
     end
 
     def parse_opts(argv, ignore_errors = false) #:nodoc:

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -120,7 +120,7 @@ module Chore
 
         def complete(id)
           Chore.logger.debug "Completing (deleting): #{id}"
-          FileUtils.rm_f(File.join(@in_progress_dir, id))
+          File.delete(File.join(@in_progress_dir, id))
         end
 
         private

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -92,7 +92,7 @@ module Chore
 
           @in_progress_dir = self.class.in_progress_dir(queue_name)
           @new_dir = self.class.new_dir(queue_name)
-          @queue_timeout = Chore.config.default_queue_timeout
+          @queue_timeout = self.class.queue_timeout(queue_name)
         end
 
         def consume

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -46,15 +46,13 @@ module Chore
 
           # Moves job file to inprogress directory and returns the full path
           def move_job(from, to)
-            f = File.open(from, "r")
-            # wait on the lock a publisher in another process might have.
-            # Once we get the lock the file is ours to move to mark it in progress
-            f.flock(File::LOCK_EX)
-            begin
+            File.open(from, "r") do |f|
+              # wait on the lock a publisher in another process might have.
+              # Once we get the lock the file is ours to move to mark it in progress
+              f.flock(File::LOCK_EX)
               FileUtils.mv(f.path, to)
-            ensure
-              f.flock(File::LOCK_UN) # yes we can unlock it after its been moved, I checked
             end
+
             to
           end
 

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -35,23 +35,28 @@ module Chore
             end
           end
 
-          def make_in_progress(job, new_dir, in_progress_dir)
-            move_job(File.join(new_dir, job), File.join(in_progress_dir, job))
-          end
-
-          def make_new_again(job, new_dir, in_progress_dir)
-            basename, previous_attempts = file_info(job)
-            move_job(File.join(in_progress_dir, job), File.join(new_dir, "#{basename}.#{previous_attempts + 1}.job"))
-          end
-
           # Moves job file to inprogress directory and returns the full path
-          def move_job(from, to)
+          def make_in_progress(job, new_dir, in_progress_dir)
+            from = File.join(new_dir, job)
+            to = File.join(in_progress_dir, job)
+
             File.open(from, "r") do |f|
               # wait on the lock a publisher in another process might have.
               # Once we get the lock the file is ours to move to mark it in progress
               f.flock(File::LOCK_EX)
-              FileUtils.mv(f.path, to)
+              FileUtils.mv(from, to)
             end
+
+            to
+          end
+
+          # Moves job file to new directory and returns the full path
+          def make_new_again(job, new_dir, in_progress_dir)
+            basename, previous_attempts = file_info(job)
+
+            from = File.join(in_progress_dir, job)
+            to = File.join(new_dir, "#{basename}.#{previous_attempts + 1}.job")
+            FileUtils.mv(from, to)
 
             to
           end

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -100,7 +100,7 @@ module Chore
             rescue => e
               Chore.logger.error { "#{self.class}#consume: #{e} #{e.backtrace * "\n"}" }
             ensure
-              sleep 5 unless found_files
+              sleep(Chore.config.consumer_sleep_interval) unless found_files
             end
           end
         end

--- a/lib/chore/queues/filesystem/filesystem_queue.rb
+++ b/lib/chore/queues/filesystem/filesystem_queue.rb
@@ -6,6 +6,8 @@ module Chore::FilesystemQueue
   NEW_JOB_DIR = "new"
   # Local directory for jobs currently in-process to be moved
   IN_PROGRESS_DIR = "inprogress"
+  # Local directory for configuration info
+  CONFIG_DIR = "config"
   
   # Retrieves the directory for in-process messages to go. If the directory for the +queue_name+ doesn't exist,
   # it will be created for you. If the directory cannot be created, an IOError will be raised
@@ -27,6 +29,23 @@ module Chore::FilesystemQueue
   # Returns the fully qualified path to the directory for +queue_name+
   def queue_dir(queue_name)
     prepare_dir(File.join(root_dir, queue_name))
+  end
+
+  # The configuration for the given queue
+  def config_dir(queue_name)
+    validate_dir(queue_name, CONFIG_DIR)
+  end
+
+  def config_value(queue_name, config_name)
+    config_file = File.join(config_dir(queue_name), config_name)
+    if File.exists?(config_file)
+      File.read(config_file).strip
+    end
+  end
+
+  # Returns the timeout for +queue_name+
+  def queue_timeout(queue_name)
+    (config_value(queue_name, 'timeout') || Chore.config.default_queue_timeout).to_i
   end
 
   private

--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -34,7 +34,7 @@ module Chore
           while running?
             begin
               messages = handle_messages(&handler)
-              sleep (Chore.config.consumer_sleep_interval || 1) if messages.empty?
+              sleep (Chore.config.consumer_sleep_interval) if messages.empty?
             rescue AWS::SQS::Errors::NonExistentQueue => e
               Chore.logger.error "You specified a queue '#{queue_name}' that does not exist. You must create the queue before starting Chore. Shutting down..."
               raise Chore::TerribleMistake

--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -16,12 +16,11 @@ module Chore
         Chore::CLI.register_option 'aws_access_key', '--aws-access-key KEY', 'Valid AWS Access Key'
         Chore::CLI.register_option 'aws_secret_key', '--aws-secret-key KEY', 'Valid AWS Secret Key'
         Chore::CLI.register_option 'dedupe_servers', '--dedupe-servers SERVERS', 'List of mememcache compatible server(s) to use for storing SQS Message Dedupe cache'
-        Chore::CLI.register_option 'queue_polling_size', '--queue_polling_size NUM', Integer, 'Amount of messages to grab on each request' do |arg|
-          raise ArgumentError, "Cannot specify a queue polling size greater than 10" if arg > 10
-        end
 
         def initialize(queue_name, opts={})
           super(queue_name, opts)
+
+          raise Chore::TerribleMistake, "Cannot specify a queue polling size greater than 10" if sqs_polling_amount > 10
         end
 
         # Sets a flag that instructs the publisher to reset the connection the next time it's used
@@ -120,7 +119,7 @@ module Chore
         end
 
         def sqs_polling_amount
-          Chore.config.queue_polling_size || 10
+          Chore.config.queue_polling_size
         end
       end
     end

--- a/spec/chore/cli_spec.rb
+++ b/spec/chore/cli_spec.rb
@@ -201,8 +201,8 @@ describe Chore::CLI do
 
       context 'given no value' do
         let(:command) { [] }
-        it 'is the default value, nil' do
-          subject.should == nil
+        it 'is the default value, 1' do
+          subject.should == 1
         end
       end
     end

--- a/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
+++ b/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
@@ -47,10 +47,10 @@ describe Chore::Queues::Filesystem::Consumer do
     end
   end
 
-  describe ".job_files" do
+  describe ".each_job_file" do
     it "should list jobs in dir" do
       FileUtils.touch("#{new_dir}/foo.1.job")
-      expect(described_class.job_files(new_dir)).to eq(["foo.1.job"])
+      expect {|b| described_class.each_job_file(new_dir, &b) }.to yield_with_args("foo.1.job")
     end
   end
 

--- a/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
+++ b/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
@@ -47,10 +47,10 @@ describe Chore::Queues::Filesystem::Consumer do
     end
   end
 
-  describe ".each_job_file" do
+  describe ".each_file" do
     it "should list jobs in dir" do
       FileUtils.touch("#{new_dir}/foo.1.job")
-      expect {|b| described_class.each_job_file(new_dir, &b) }.to yield_with_args("foo.1.job")
+      expect {|b| described_class.each_file("#{new_dir}/*.job", &b) }.to yield_with_args("foo.1.job")
     end
   end
 


### PR DESCRIPTION
This makes a variety of performance / memory improvements to the filesystem consumer.  These are particularly effective when working with large backlogs.  This PR is best reviewed commit-by-commit.  Each change stands on its own, but I've bundled them into a single PR for the purpose of full context and how they're related.

Note that the reason I'm making these changes instead of investing time into the Go sidecar / FS queue is because there are only a few things we need to do to get our existing Ruby sidecar / FS queue behaving well enough to stand on its own.  Investing time into a Go implementation is a much larger chunk of work.

The following changes were made:

1. Only sleep between lookups in the filesystem consumer if files aren't found

Currently we sleep for 5s every time we we look at the filesystem for new files.  This means that we lose up to 5s of processing if our batch size is 100 and 100 new jobs appear immediately after we've consumed from the filesystem.

With this change, we will now only sleep if no new files have appeared since the last time we looked at the filesystem.  That is, if we look at the filesystem and there are no jobs to consume, then we'll sleep.

This helps avoid those times when we're just sitting there doing nothing even though there are jobs on the queue.

2. Determine fileystem consumer sleep time based on the consumer_sleep_interval Chore configuration

After the above change, we still now sleep for 5s when we don't find any new jobs on the filesystem which is still inefficient if the job workload is spiky.  With this change, we could drop the sleep time to 100ms via the consumer_sleep_interval configuration.  Even at 100ms, it's fast enough that we'll pick up new jobs pretty quickly off the filesystem and slow enough that we're not creating unnecessary CPU load.  The default will be 1s to match what we're doing in SQS.

3. Limit the number of files pulled from the filesystem on each iteration

Currently we pull all of the files off the filesystem at once when the consumer reads from the queue.  This can have a significant performance impact because if the queue is large enough we can exhaust our memory or open file limit.

Instead, we now only grab up to the configured queue_polling_size size at once.  With changes #1 and #2 in place, this is effectively as efficient as pulling all the files at once but without pulling it all into memory at once.

4. Don't keep files open forever (or at least until the file is deleted)

When we move job files from the new folder to the in progress folder, we open the file, lock it, but then never actually close the file.  Fortunately Ruby (or the OS) seems to be doing something smart here in that it somehow closes the open file when the file gets deleted.  However, it still leads to a lot more open files than there should be for the process.

With this change, we now close the file once we've locked it and moved it to "in progress".  Closing the file automatically unlocks it so we no longer need the unlock function.

5. Only lock files when moving them into the "in progress" directory

We only need to lock files when we're moving them from "new" to "in progress" in order to prevent us from moving files that are being written to by a publisher.  Once a consumer thread has moved it to "in progress", there's nothing any process is going to do to those files.  As a result, there's no need to lock the file again when moving it back to "new" since the consumer isn't competing with any other thread / process.

6. Don't block on files in the process of being written by the filesystem publisher

Currently we using a blocking lock when moving files from "new" to "in progress".  This is inefficient because if there are 1,000 jobs available to process and 1 job still being written by a publisher, we're going to wait on that publisher to finish writing even though we have 1,000 other jobs we could be processing.

Instead of using a blocking wait, this change moves us to a *non-blocking* wait.  It allows us to skip files that are still being written so that we can process all of the files that are ready.  On the next iteration of the consumer thread, we'll pick up the file that previously got skipped

7. Use Dir.glob instead of Dir.foreach in the filesystem consumer

This is more of a refactor and a forward-looking change than anything.  Currently we use `Dir.foreach` which pulls in directories like `.` and `..` in the results so we need to explicitly skip them.  Instead, we can use `Dir.glob` and avoid the need to check for directory names like that.

8. Support running multiple threaded consumers with the filesystem queue

Currently we only support a single consumer thread per queue.  This doesn't allow flexibility in the Chore configuration should we need to support multiple consumer threads (if, for example, we're bound by a single cpu for reading from the filesystem).

The change is actually fairly straightforward and, in fact, simplifies the filesystem queue configuration.  The main change needed here was just to be able to handle the fact that a file that another thread may have already moved into "in progress" could no longer exist.  Other than that, all of the existing functionality already supports parallel threads / processes reading job files from the "new" directory.

This also negates our need for the use of mutexes since the different consumer threads will handle the case when another thread is reading the same new job file.

9. Use File.delete instead of FileUtils.rm_f to reduce CPU usage in the filesystem consumer

`FileUtils.rm_f` does a lot of stuff under the hood that's necessary when all we want to do is delete a file off the filesystem.  This results in a bunch of additional CPU usage during high throughput scenarios.  By switching to the simpler `File.delete`, we effectively get the same functionality at a much lower cost to the CPU.

10. Support queue-specific configurations (like timeouts) in the filesystem consumer

Currently, the visibility timeout for every filesystem queue is based off the default queue timeout for the entire application.  This doesn't align with the behavior we have with SQS queues where the visibility timeout is configured at the source (i.e. on SQS itself).  In order to improve parity between the filesystem queue and SQS, this allows you to define queue-specific configurations on the filesystem.

Configurations will be read from a new "config" directory under the queue's root
directory (e.g. queue_name/config/timeout).  Currently the only configuration supported is `timeout`.

I felt that having individual files for different types of configurations would allow different extensions of chore to be able to have their own customized configurations.  We could do something like a JSON / YAML file, but it didn't seem necessary to have something that complicated just yet.  We could look at that in the future if we found the need.

## Follow-ups

There will be one more follow-up improvement (in a separate PR) to support multi-master mode with the filesystem queue.

## TODO

* [x] Verify changes locally