### PR TITLE
Allow the master / worker proclines to be configured by the app

### DIFF
--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -41,7 +41,9 @@ module Chore #:nodoc:
     :shutdown_timeout      => (2 * 60),
     :max_attempts          => 1.0 / 0.0, # Infinity
     :dupe_on_cache_failure => false,
-    :payload_handler       => Chore::Job
+    :payload_handler       => Chore::Job,
+    :master_procline       => "chore-master-#{Chore::VERSION}",
+    :worker_procline       => "chore-worker-#{Chore::VERSION}"
   }
 
   class << self

--- a/lib/chore/manager.rb
+++ b/lib/chore/manager.rb
@@ -10,7 +10,7 @@ module Chore
     def initialize()
       Chore.logger.info "Booting Chore #{Chore::VERSION}"
       Chore.logger.debug { Chore.config.inspect }
-      procline("chore-master-#{Chore::VERSION}:Started:#{Time.now}")
+      procline("#{Chore.config.master_procline}:Started:#{Time.now}")
       @started_at = nil
       @worker_strategy = Chore.config.worker_strategy.new(self)
       @fetcher = Chore.config.fetcher.new(self)

--- a/lib/chore/strategies/worker/forked_worker_strategy.rb
+++ b/lib/chore/strategies/worker/forked_worker_strategy.rb
@@ -136,7 +136,7 @@ module Chore
       def after_fork(worker)
         # Immediately swap out the process name so that it doesn't look like
         # the master process
-        procline("chore-worker-#{Chore::VERSION}:Started:#{Time.now}")
+        procline("#{Chore.config.worker_procline}:Started:#{Time.now}")
 
         clear_child_signals
         trap_child_signals(worker)

--- a/lib/chore/strategies/worker/helpers/preforked_worker.rb
+++ b/lib/chore/strategies/worker/helpers/preforked_worker.rb
@@ -89,7 +89,7 @@ module Chore
       def post_fork_setup
         # Immediately swap out the process name so that it doesn't look like
         # the master process
-        procline("chore-worker-#{Chore::VERSION}:Started:#{Time.now}")
+        procline("#{Chore.config.worker_procline}:Started:#{Time.now}")
 
         # We need to reset the logger after fork. This fixes a longstanding bug
         # where workers would hang around and never die


### PR DESCRIPTION
We have some scenarios where we run multiple applications deployed onto the same servers each with their own master chore process.  Currently it's not possible to easily differentiate between these chore processes since they're all named the same.  This configuration would give applications the power to control the procline so that we can have different proclines and more easily monitor the processes.

/to @gregorysabatino @dankleiman @geoffreyclark 