### PR TITLE
Support multiple chore processes consuming from the filesystem queue

### DIFF
--- a/lib/chore/consumer.rb
+++ b/lib/chore/consumer.rb
@@ -21,11 +21,6 @@ module Chore
     def self.reset_connection!
     end
 
-    # Cleans up any resources that were left behind from prior instances of the
-    # chore process.  By default, this is a no-op.
-    def self.cleanup(queue)
-    end
-
     # Consume takes a block with an arity of two. The two params are
     # |message_id,message_body| where message_id is any object that the
     # consumer will need to be able to act on a message later (reject, complete, etc)

--- a/lib/chore/fetcher.rb
+++ b/lib/chore/fetcher.rb
@@ -11,12 +11,6 @@ module Chore
     # Starts the fetcher with the configured Consumer Strategy. This will begin consuming messages from your queue
     def start
       Chore.logger.info "Fetcher starting up"
-
-      # Clean up configured queues in case there are any resources left behind
-      Chore.config.queues.each do |queue|
-        Chore.config.consumer.cleanup(queue)
-      end
-
       @strategy.fetch
     end
 

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -137,12 +137,9 @@ module Chore
           end
         end
 
+        # Rejects the given message from the filesystem by +id+. Currently a noop
         def reject(id)
-          Chore.logger.debug "Rejecting: #{id}"
-          make_new_again(id)
-        rescue Errno::ENOENT
-          # The job took too long to complete, was deemed expired, and moved
-          # back into "new".  Ignore.
+
         end
 
         def complete(id)

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -22,22 +22,32 @@ module Chore
         Chore::CLI.register_option 'fs_queue_root', '--fs-queue-root DIRECTORY', 'Root directory for fs based queue'
         
         class << self
-          # Cleans up the in-progress files by making them new again.  This should only
-          # happen once per process.
-          def cleanup(queue)
-            new_dir = self.new_dir(queue)
-            in_progress_dir = self.in_progress_dir(queue)
+          # Cleans up expired in-progress files by making them new again.
+          def cleanup(expiration_time, new_dir, in_progress_dir)
+            each_file(File.join(in_progress_dir, '*.job')) do |job_file|
+              id, previous_attempts, timestamp = file_info(job_file)
+              next if timestamp > expiration_time
 
-            each_file(File.join(in_progress_dir, '*.job')) do |file|
-              make_new_again(file, new_dir, in_progress_dir)
+              begin
+                make_new_again(job_file, new_dir, in_progress_dir)
+              rescue Errno::ENOENT
+                # File no longer exists; skip since it's been recovered by another
+                # consumer
+              rescue ArgumentError
+                # Move operation was attempted at same time as another consumer;
+                # skip since the other process succeeded where this one didn't
+              end
             end
           end
 
           # Moves job file to inprogress directory and returns the full path
           # if the job was successfully locked by this consumer
           def make_in_progress(job, new_dir, in_progress_dir)
+            basename, previous_attempts, * = file_info(job)
+
             from = File.join(new_dir, job)
-            to = File.join(in_progress_dir, job)
+            # Add a timestamp to mark when the job was started
+            to = File.join(in_progress_dir, "#{basename}.#{previous_attempts}.#{Time.now.to_i}.job")
 
             File.open(from, "r") do |f|
               # If the lock can't be obtained, that means it's been locked
@@ -78,10 +88,18 @@ module Chore
           # Grabs the unique identifier for the job filename and the number of times
           # it's been attempted (also based on the filename)
           def file_info(job_file)
-            id, previous_attempts = File.basename(job_file, '.job').split('.')
-            [id, previous_attempts.to_i]
+            id, previous_attempts, timestamp, * = job_file.split('.')
+            [id, previous_attempts.to_i, timestamp.to_i]
           end
         end
+
+        # The minimum number of seconds to allow to pass between checks for expired
+        # jobs on the filesystem.
+        # 
+        # Since queue times are measured on the order of seconds, 1 second is the
+        # smallest duration.  It also prevents us from burning a lot of CPU looking
+        # at expired jobs when the consumer sleep interval is less than 1 second.
+        EXPIRATION_CHECK_INTERVAL = 1
 
         # The amount of time units of work can run before the queue considers
         # them timed out.  For filesystem queues, this is the global default.
@@ -99,7 +117,13 @@ module Chore
           Chore.logger.info "Starting consuming file system queue #{@queue_name} in #{self.class.queue_dir(queue_name)}"
           while running?
             begin
-              #TODO move expired job files to new directory?
+              # Move expired job files to new directory (so long as enough time has
+              # passed since we last did this check)
+              if !@last_cleaned_at || (Time.now - @last_cleaned_at).to_i >= EXPIRATION_CHECK_INTERVAL
+                self.class.cleanup(Time.now.to_i - @queue_timeout, @new_dir, @in_progress_dir)
+                @last_cleaned_at = Time.now
+              end
+
               found_files = false
               handle_jobs do |*args|
                 found_files = true
@@ -116,11 +140,17 @@ module Chore
         def reject(id)
           Chore.logger.debug "Rejecting: #{id}"
           make_new_again(id)
+        rescue Errno::ENOENT
+          # The job took too long to complete, was deemed expired, and moved
+          # back into "new".  Ignore.
         end
 
         def complete(id)
           Chore.logger.debug "Completing (deleting): #{id}"
           File.delete(File.join(@in_progress_dir, id))
+        rescue Errno::ENOENT
+          # The job took too long to complete, was deemed expired, and moved
+          # back into "new".  Ignore.
         end
 
         private
@@ -134,8 +164,11 @@ module Chore
             in_progress_path = make_in_progress(job_file)
             next unless in_progress_path
 
+            # The job filename may have changed, so update it to reflect the in progress path
+            job_file = File.basename(in_progress_path)
+
             job_json = File.read(in_progress_path)
-            basename, previous_attempts = self.class.file_info(job_file)
+            basename, previous_attempts, * = self.class.file_info(job_file)
 
             # job_file is just the name which is the job id
             block.call(job_file, queue_name, queue_timeout, job_json, previous_attempts)

--- a/spec/chore/consumer_spec.rb
+++ b/spec/chore/consumer_spec.rb
@@ -22,10 +22,6 @@ describe Chore::Consumer do
     Chore::Consumer.should respond_to :reset_connection!
   end
 
-  it 'should have a class level cleanup method' do
-    Chore::Consumer.should respond_to :cleanup
-  end
-
   it 'should not have an implemented consume method' do
     expect { consumer.consume }.to raise_error(NotImplementedError)
   end

--- a/spec/chore/fetcher_spec.rb
+++ b/spec/chore/fetcher_spec.rb
@@ -35,15 +35,4 @@ describe Chore::Fetcher do
       fetcher.start
     end
   end
-
-  describe "cleaning up" do
-    before(:each) do
-      manager.stub(:assign)
-    end
-    
-    it "should run cleanup on each queue" do
-      consumer.should_receive(:cleanup).with('test')
-      fetcher.start
-    end
-  end
 end

--- a/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
+++ b/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
@@ -112,7 +112,9 @@ describe Chore::Queues::Filesystem::Consumer do
           end
           expect(rejected).to be true
 
-          expect { |b| consumer.consume(&b) }.to yield_with_args(anything, 'test-queue', 60, test_job_hash.to_json, 1)
+          Timecop.freeze(Time.now + 61) do
+            expect { |b| consumer.consume(&b) }.to yield_with_args(anything, 'test-queue', 60, test_job_hash.to_json, 1)
+          end
         end
       end
 

--- a/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
+++ b/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
@@ -30,25 +30,46 @@ describe Chore::Queues::Filesystem::Consumer do
   let(:config_dir) { described_class.config_dir(test_queue) }
 
   describe ".cleanup" do
-    it "should move in_progress jobs to new dir" do
-      FileUtils.touch("#{in_progress_dir}/foo.1.job")
-      described_class.cleanup(test_queue)
+    it "should move expired in_progress jobs to new dir" do
+      timestamp = Time.now.to_i - 1
+
+      FileUtils.touch("#{in_progress_dir}/foo.1.#{timestamp}.job")
+      described_class.cleanup(Time.now.to_i, new_dir, in_progress_dir)
       expect(File.exist?("#{new_dir}/foo.2.job")).to eq(true)
+    end
+
+    it "should move non-timestamped jobs from in_progress_dir to new dir" do
+      FileUtils.touch("#{in_progress_dir}/foo.1.job")
+      described_class.cleanup(Time.now.to_i, new_dir, in_progress_dir)
+      expect(File.exist?("#{new_dir}/foo.2.job")).to eq(true)
+    end
+
+    it "should not affect non-expired jobs" do
+      timestamp = Time.now.to_i - 1
+
+      FileUtils.touch("#{in_progress_dir}/foo.1.#{timestamp}.job")
+      described_class.cleanup(Time.now.to_i - 2, new_dir, in_progress_dir)
+      expect(File.exist?("#{new_dir}/foo.2.job")).to eq(false)
     end
   end
 
   describe ".make_in_progress" do
     it "should move job to in_progress dir" do
-      FileUtils.touch("#{new_dir}/foo.1.job")
-      described_class.make_in_progress("foo.1.job", new_dir, in_progress_dir)
-      expect(File.exist?("#{in_progress_dir}/foo.1.job")).to eq(true)
+      now = Time.now
+
+      Timecop.freeze(now) do
+        FileUtils.touch("#{new_dir}/foo.1.job")
+        described_class.make_in_progress("foo.1.job", new_dir, in_progress_dir)
+        expect(File.exist?("#{in_progress_dir}/foo.1.#{now.to_i}.job")).to eq(true)
+      end
     end
   end
 
   describe ".make_new_again" do
     it "should move job to new dir" do
-      FileUtils.touch("#{in_progress_dir}/foo.1.job")
-      described_class.make_new_again("foo.1.job", new_dir, in_progress_dir)
+      timestamp = Time.now.to_i
+      FileUtils.touch("#{in_progress_dir}/foo.1.#{timestamp}.job")
+      described_class.make_new_again("foo.1.#{timestamp}.job", new_dir, in_progress_dir)
       expect(File.exist?("#{new_dir}/foo.2.job")).to eq(true)
     end
   end


### PR DESCRIPTION
In order to give us more flexibility in how we configure and deploy chore as a filesystem sidecar queue, this adds support for being able to run multiple chore masters or multiple forked workers.  Currently this is supported for external services like SQS; however, we don't have graceful support for it in the filesystem.

Similar to https://github.com/Tapjoy/chore/pull/43, this gets us a lot more flexibility in deployment configuration without investing time into a Go-based filesystem queue sidecar.

## Design

Currently the filesystem queue already supports multiple consumers across different processes.  However, the problem we still need to solve is what happens to in-progress jobs when a forked worker or master process dies.  The current implementation assumes only 1 master is ever running at a time.  This is because, on startup, it will immediately move everything out of "in progress" and into "new".  This works in a single master scenario since you can assume no one is processing the stuff that's in progress.  However, in multi-master, some of those jobs may be expired / leftover from old killed processes and some may be actively getting processed by a live master.

To address this, we take a page out of SQS's book.  We'll only ever delete from "in progress" if the job was completed *or* the job has expired based on the queue's visibility timeout.  The former is the normal scenario.  In the latter, jobs will expire if either (a) they took too long to process or (b) the process that owned the job was killed.

To track expiration time, we put a timestamp into the job's filename for when it was moved into "in progress".  This is necessary since neither the creation, modification, or access times change when the file moves.  This expiration time gets removed when the file is moved back into "new".

In addition to this periodic cleanup process, additionally error handling is needed in order to account for scenarios where we are both completing a job and cleaning up the job simulatenously.

## Performance

From a performance perspective, this is negligible unless there is a large backlog of files in "new".  In that case, we only allow the "new" folder to be cleaned up at most once a second in order to avoid a performance impact.  Once nice thing from this is that it actually allows for some delay before the job gets retried (jobs only get retried once every `visibility timeout` seconds).

## Summary

In summary, we've made the filesystem queue behave much more in line with how SQS behaves -- allowing us to make more sense of how jobs will behave regardless of the queue selected.

## TODO

* [x] Verify locally