### PR TITLE
Use Dir.foreach instead of Dir.glob to fix a performance regression

### DIFF
--- a/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
+++ b/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
@@ -77,7 +77,7 @@ describe Chore::Queues::Filesystem::Consumer do
   describe ".each_file" do
     it "should list jobs in dir" do
       FileUtils.touch("#{new_dir}/foo.1.job")
-      expect {|b| described_class.each_file("#{new_dir}/*.job", &b) }.to yield_with_args("foo.1.job")
+      expect {|b| described_class.each_file(new_dir, &b) }.to yield_with_args("foo.1.job")
     end
   end
 


### PR DESCRIPTION
When a queue has a large backlog, `Dir.glob` performs much more poorly than `Dir.foreach`.  I had originally switched to `glob` to simplify the code, but the performance regression is way more than its worth.  See below for a directory with 200k jobs:

```
2.3.0 :015 > Benchmark.measure { index = 0; Dir.glob('/mnt/chore_fs_queue/development_web_requests/new/*.job') {|f| index += 1; break if index >= 1000 } }
 => #<Benchmark::Tms:0x0000000214cb50 @label="", @real=0.5653504389993032, @cstime=0.0, @cutime=0.0, @stime=0.2999999999999998, @utime=0.26000000000000023, @total=0.56> 
2.3.0 :016 > Benchmark.measure { index = 0; Dir.foreach('/mnt/chore_fs_queue/development_web_requests/new/') {|f| index += 1; break if index >= 1000 } }
 => #<Benchmark::Tms:0x000000031ef318 @label="", @real=0.0012892550003016368, @cstime=0.0, @cutime=0.0, @stime=0.0, @utime=0.0, @total=0.0> 
```

As you can see, `Dir.foreach` can be over 500x faster.  This is pretty critical so that the majority of your time isn't spent just listing files off the filesystem.

/to @gregorysabatino @dankleiman @geoffreyclark 