### PR TITLE
Fix filesystem publisher potentially leaving files locked until the Ruby process exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
 **Cleanups**
 - N/A
 
+## [v3.1.0](https://github.com/Tapjoy/chore/tree/v3.1.0) (2017-09-15)
+
+**Features**
+- N/A
+
+**Fixed bugs**
+- Fix the filesystem publisher potentially leaving job files locked for process's lifetime
+
+**Cleanups**
+- N/A
+
 ## [v3.0.2](https://github.com/Tapjoy/chore/tree/v3.0.2) (2017-09-07)
 
 **Features**

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -33,7 +33,8 @@ module Chore
         def filename(queue_name, job_name)
           now = Time.now.strftime "%Y%m%d-%H%M%S-%6N"
           previous_attempts = 0
-          File.join(new_dir(queue_name), "#{queue_name}-#{job_name}-#{now}.#{previous_attempts}.job")
+          pid = Process.pid
+          File.join(new_dir(queue_name), "#{queue_name}-#{job_name}-#{pid}-#{now}.#{previous_attempts}.job")
         end
       end
     end

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -20,7 +20,7 @@ module Chore
           while !published
             # keep trying to get a file with nothing in it meaning we just created it
             # as opposed to us getting someone else's file that hasn't been processed yet.
-            File.open(filename(queue_name, job[:class].to_s), "w") do |f|
+            File.open(filename(queue_name, job[:class].to_s), "a") do |f|
               if f.flock(File::LOCK_EX | File::LOCK_NB) && f.size == 0
                 f.write(encoded_job)
                 published = true

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -10,27 +10,20 @@ module Chore
         # See the top of FilesystemConsumer for comments on how this works
         include FilesystemQueue
 
-        # Mutex for holding a lock over the files for this queue while they are in process
-        FILE_MUTEX = Mutex.new
-
         # use of mutex and file locking should make this both threadsafe and safe for multiple
         # processes to use the same queue directory simultaneously. 
         def publish(queue_name,job)
           # First try encoding the job to avoid writing empty job files if this fails
           encoded_job = encode_job(job)
 
-          FILE_MUTEX.synchronize do
-            while true
-              # keep trying to get a file with nothing in it meaning we just created it
-              # as opposed to us getting someone else's file that hasn't been processed yet.
-              f = File.open(filename(queue_name, job[:class].to_s), "w")
+          published = false
+          while !published
+            # keep trying to get a file with nothing in it meaning we just created it
+            # as opposed to us getting someone else's file that hasn't been processed yet.
+            File.open(filename(queue_name, job[:class].to_s), "w") do |f|
               if f.flock(File::LOCK_EX | File::LOCK_NB) && f.size == 0
-                begin
-                  f.write(encoded_job)
-                ensure
-                  f.flock(File::LOCK_UN)
-                end
-                break
+                f.write(encoded_job)
+                published = true
               end
             end
           end

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -1,8 +1,8 @@
 module Chore
   module Version #:nodoc:
     MAJOR = 3
-    MINOR = 0
-    PATCH = 2
+    MINOR = 1
+    PATCH = 0
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')
   end


### PR DESCRIPTION
This makes a few fixes to how we publish files to the filesystem from chore:

1. When the filesystem publisher chooses a filename, it's possible that it conflicts with another file that already exists if the file gets created within a short enough timeframe in the same process.  When this happens, the file will be left in a permanently locked state until the Ruby process exits since we don't explicitly unlock the file in that case.

2. The file mutex isn't used because we only publish one file at a time in a single process (not multi-threaded) and we already have handling for conflicting files.

3. By using "w" as the file flag, Ruby documents that this can truncate existing files.  To avoid that, I've switched it to "a" which will either create or append files.  In the append case, we'll never actually append because we only write to the file if it's size is 0.

4. Add the process id into the filename for the job to reduce the potential for filename conflicts between 2 separate publisher processes.

/to @gregorysabatino @dankleiman @jjrussell 