### PR TITLE
[DMMEAS-1646] adds chore queue option to dedupe on arbitrary value per job

### DIFF
--- a/lib/chore/consumer.rb
+++ b/lib/chore/consumer.rb
@@ -53,5 +53,15 @@ module Chore
     def provide_work(n)
       raise NotImplementedError
     end
+
+    # now, given an arbitrary key and klass, have we seen the key already?
+    def duplicate_message?(dedupe_key, klass, queue_timeout)
+      dupe_detector.found_duplicate?(:id=>dedupe_key, :queue=>klass.to_s, :visibility_timeout=>queue_timeout)
+    end
+
+    def dupe_detector
+      @dupes ||= DuplicateDetector.new({:servers => Chore.config.dedupe_servers,
+                                        :dupe_on_cache_failure => false})
+    end
   end
 end

--- a/lib/chore/job.rb
+++ b/lib/chore/job.rb
@@ -60,6 +60,12 @@ module Chore
             raise ArgumentError, "#{self.to_s}: backoff must accept a single argument"
           end
         end
+
+        if @chore_options.key?(:dedupe_lambda)
+          if !@chore_options[:dedupe_lambda].is_a?(Proc)
+            raise ArgumentError, "#{self.to_s}: dedupe_lambda must be a lambda or Proc"
+          end
+        end
       end
 
       # This is a method so it can be overriden to create additional required
@@ -107,6 +113,17 @@ module Chore
       # the key at this point.
       def has_backoff?
         self.options.key?(:backoff)
+      end
+
+      def has_dedupe_lambda?
+        self.options.key?(:dedupe_lambda)
+      end
+
+      def dedupe_key(*args)
+        return unless has_dedupe_lambda?
+
+        # run the proc to get the key
+        self.options[:dedupe_lambda].call(*args).to_s
       end
     end #ClassMethods
 

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -1,7 +1,7 @@
 module Chore
   module Version #:nodoc:
     MAJOR = 3
-    MINOR = 1
+    MINOR = 2
     PATCH = 0
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')

--- a/spec/chore/duplicate_detector_spec.rb
+++ b/spec/chore/duplicate_detector_spec.rb
@@ -2,7 +2,21 @@ require 'spec_helper'
 require 'securerandom'
 
 describe Chore::DuplicateDetector do
-  let(:memcache) { double("memcache") }
+  class FakeDalli
+    def initialize
+      @store = {}
+    end
+    def add(id, val, ttl=0)
+      if @store[id] && @store[id][:inserted] + @store[id][:ttl] > Time.now.to_i
+        return false
+      else
+        @store[id] = {:val => val, :ttl => ttl, :inserted => Time.now.to_i}
+        return true
+      end
+    end
+  end
+
+  let(:memcache) { FakeDalli.new }
   let(:dupe_on_cache_failure) { false }
   let(:dedupe_params)  { { :memcached_client => memcache, :dupe_on_cache_failure => dupe_on_cache_failure } }
   let(:dedupe) { Chore::DuplicateDetector.new(dedupe_params)}
@@ -15,12 +29,11 @@ describe Chore::DuplicateDetector do
 
   describe "#found_duplicate" do
     it 'should not return true if the message has not already been seen' do
-      expect(memcache).to receive(:add).and_return(true)
       expect(dedupe.found_duplicate?(message_data)).to_not be true
     end
 
     it 'should return true if the message has already been seen' do
-      expect(memcache).to receive(:add).and_return(false)
+      memcache.add(message_data[:id], 1, message_data[:visibility_timeout])
       expect(dedupe.found_duplicate?(message_data)).to be true
     end
 
@@ -34,13 +47,12 @@ describe Chore::DuplicateDetector do
     end
 
     it "should set the timeout to be the queue's " do
-      expect(memcache).to receive(:add).with(id,"1",timeout).and_return(true)
+      expect(memcache).to receive(:add).with(id,"1",timeout).and_call_original
       expect(dedupe.found_duplicate?(message_data)).to be false
     end
 
     it "should call #visibility_timeout once and only once" do
       expect(queue).to receive(:visibility_timeout).once
-      expect(memcache).to receive(:add).at_least(3).times.and_return(true)
       3.times { dedupe.found_duplicate?(message_data) }
     end
 

--- a/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
@@ -23,6 +23,10 @@ describe Chore::Strategy::ForkedWorkerStrategy do
   let!(:worker) { Chore::Worker.new(job) }
   let(:pid) { Random.rand(2048) }
 
+  before(:each) do
+    allow(consumer).to receive(:duplicate_message?).and_return(false)
+  end
+
   after(:each) do
     allow(Process).to receive(:kill) { nil }
     allow(Process).to receive(:wait) { pid }


### PR DESCRIPTION
The goal of this PR is to allow chore jobs to define a custom lambda to be called before `perform`, the results of which we would use as a key to dedupe the job runs. We currently do part of this today for sqs message ids (sqs is "at-least once") in `sqs/consumer.rb`. Part of this PR refactors the code so that we are either doing one dedupe: using the custom job-defined function, or falling back to using the message id. 

A random sided-benefit of this PR is that by moving the deduping code from the `sqs/consumer` class to the `worker`, we actually _gain_ the ability to dedupe on filesystem queues which wasn't previously possible before.

One thing to keep in mind when reviewing this code is that the same chore triggers should be called as they were previously on duplicate messages. The behavior for dedupe-key-duplicates is slightly different, but making sure call the same callbacks is important.

I've also added some specs and have done manual testing by doing the following:
1. Modifying a tapinabox so that a job class has a `dedupe_lambda` defined, like:
```
class NonManagedSendCurrencyJob
  include Chore::Job
  include SendCurrencyJobHelper

  queue_options :name => "v2_NonManagedSendCurrency", :dedupe_lambda => lambda {|reward_id, options = {}| reward_id }
end
```
2. Generate a uuid in the console and call the job several times very quickly.
```
2.4.1 :006 > u = UUIDTools::UUID.random_create.to_s
 => "38df22f9-1cec-4c8d-87b1-28fa23e273c6"
2.4.1 :007 > NonManagedSendCurrencyJob.perform_async(u)
^[[A[2019-06-03 15:36:48 +0000 (4124)] DEBUG : [AWS SQS 200 0.264393 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v2_NonManagedSendCurrency")


[2019-06-03 15:36:48 +0000 (4124)] DEBUG : [AWS SQS 200 0.069394 0 retries] send_message(:message_body=>"{\"class\":\"NonManagedSendCurrencyJob\",\"args\":[\"38df22f9-1cec-4c8d-87b1-28fa23e273c6\"]}",:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v2_NonManagedSendCurrency")

 => [[]]
2.4.1 :008 > NonManagedSendCurrencyJob.perform_async(u)
[2019-06-03 15:36:48 +0000 (4124)] DEBUG : [AWS SQS 200 0.064696 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v2_NonManagedSendCurrency")

[2019-06-03 15:36:48 +0000 (4124)] DEBUG : [AWS SQS 200 0.107138 0 retries] send_message(:message_body=>"{\"class\":\"NonManagedSendCurrencyJob\",\"args\":[\"38df22f9-1cec-4c8d-87b1-28fa23e273c6\"]}",:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v2_NonManagedSendCurrency")

 => [[]]
2.4.1 :009 > NonManagedSendCurrencyJob.perform_async(u)
[2019-06-03 15:36:48 +0000 (4124)] DEBUG : [AWS SQS 200 0.064533 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v2_NonManagedSendCurrency")

[2019-06-03 15:36:49 +0000 (4124)] DEBUG : [AWS SQS 200 0.068809 0 retries] send_message(:message_body=>"{\"class\":\"NonManagedSendCurrencyJob\",\"args\":[\"38df22f9-1cec-4c8d-87b1-28fa23e273c6\"]}",:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v2_NonManagedSendCurrency")

 => [[]]
2.4.1 :010 > NonManagedSendCurrencyJob.perform_async(u)
[2019-06-03 15:36:49 +0000 (4124)] DEBUG : [AWS SQS 200 0.06444 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v2_NonManagedSendCurrency")

[2019-06-03 15:36:49 +0000 (4124)] DEBUG : [AWS SQS 200 0.071577 0 retries] send_message(:message_body=>"{\"class\":\"NonManagedSendCurrencyJob\",\"args\":[\"38df22f9-1cec-4c8d-87b1-28fa23e273c6\"]}",:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v2_NonManagedSendCurrency")

 => [[]]
2.4.1 :011 > NonManagedSendCurrencyJob.perform_async(u)
[2019-06-03 15:36:49 +0000 (4124)] DEBUG : [AWS SQS 200 0.064222 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v2_NonManagedSendCurrency")

[2019-06-03 15:36:49 +0000 (4124)] DEBUG : [AWS SQS 200 0.066898 0 retries] send_message(:message_body=>"{\"class\":\"NonManagedSendCurrencyJob\",\"args\":[\"38df22f9-1cec-4c8d-87b1-28fa23e273c6\"]}",:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v2_NonManagedSendCurrency")

 => [[]]
2.4.1 :012 > NonManagedSendCurrencyJob.perform_async(u)
[2019-06-03 15:36:49 +0000 (4124)] DEBUG : [AWS SQS 200 0.065662 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v2_NonManagedSendCurrency")

[2019-06-03 15:36:49 +0000 (4124)] DEBUG : [AWS SQS 200 0.067002 0 retries] send_message(:message_body=>"{\"class\":\"NonManagedSendCurrencyJob\",\"args\":[\"38df22f9-1cec-4c8d-87b1-28fa23e273c6\"]}",:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v2_NonManagedSendCurrency")

 => [[]]
2.4.1 :013 > NonManagedSendCurrencyJob.perform_async(u)
[2019-06-03 15:36:50 +0000 (4124)] DEBUG : [AWS SQS 200 0.065321 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v2_NonManagedSendCurrency")

[2019-06-03 15:36:50 +0000 (4124)] DEBUG : [AWS SQS 200 0.069942 0 retries] send_message(:message_body=>"{\"class\":\"NonManagedSendCurrencyJob\",\"args\":[\"38df22f9-1cec-4c8d-87b1-28fa23e273c6\"]}",:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v2_NonManagedSendCurrency")

 => [[]]
```
3. Observe the chore logs and see that perform is only called *once* every 40 or so seconds (the `ERROR` lines), while the duplicates to come in after the first run are deleted.
```
Jun  5 15:30:29 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:28 +0000 (1786)] INFO : Running job NonManagedSendCurrencyJob with params {"class"=>"NonManagedSendCurrencyJob", "args"=>["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]}
Jun  5 15:30:29 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:28 +0000 (1786)] ERROR : Failed to run job {"class":"NonManagedSendCurrencyJob","args":["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]} with error: Reward not found: 09d3fd0a-5736-4b25-8535-1f63675f0a4b at /opt/apps/tapjoyserver/releases/tapjoyserver-20190605135114-98dea6193b/app/helpers/send_currency_job_helper.rb:52:in `perform'
Jun  5 15:30:29 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:28 +0000 (1786)] INFO : Found and deleted duplicate job NonManagedSendCurrencyJob
Jun  5 15:30:29 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:28 +0000 (1786)] INFO : Found and deleted duplicate job NonManagedSendCurrencyJob
Jun  5 15:30:29 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:29 +0000 (1786)] INFO : Found and deleted duplicate job NonManagedSendCurrencyJob
Jun  5 15:31:30 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:29 +0000 (1786)] INFO : Found and deleted duplicate job NonManagedSendCurrencyJob
Jun  5 15:31:30 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:29 +0000 (1786)] INFO : Found and deleted duplicate job NonManagedSendCurrencyJob
Jun  5 15:31:30 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:59 +0000 (1786)] INFO : Running job NonManagedSendCurrencyJob with params {"class"=>"NonManagedSendCurrencyJob", "args"=>["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]}
Jun  5 15:31:30 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:30:59 +0000 (1786)] ERROR : Failed to run job {"class":"NonManagedSendCurrencyJob","args":["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]} with error: Reward not found: 09d3fd0a-5736-4b25-8535-1f63675f0a4b at /opt/apps/tapjoyserver/releases/tapjoyserver-20190605135114-98dea6193b/app/helpers/send_currency_job_helper.rb:52:in `perform'
Jun  5 15:31:30 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:31:30 +0000 (1786)] INFO : Running job NonManagedSendCurrencyJob with params {"class"=>"NonManagedSendCurrencyJob", "args"=>["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]}
Jun  5 15:31:30 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:31:30 +0000 (1786)] ERROR : Failed to run job {"class":"NonManagedSendCurrencyJob","args":["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]} with error: Reward not found: 09d3fd0a-5736-4b25-8535-1f63675f0a4b at /opt/apps/tapjoyserver/releases/tapjoyserver-20190605135114-98dea6193b/app/helpers/send_currency_job_helper.rb:52:in `perform'
Jun  5 15:32:37 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:32:05 +0000 (1786)] INFO : Running job NonManagedSendCurrencyJob with params {"class"=>"NonManagedSendCurrencyJob", "args"=>["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]}
Jun  5 15:32:37 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:32:05 +0000 (1786)] ERROR : Failed to run job {"class":"NonManagedSendCurrencyJob","args":["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]} with error: Reward not found: 09d3fd0a-5736-4b25-8535-1f63675f0a4b at /opt/apps/tapjoyserver/releases/tapjoyserver-20190605135114-98dea6193b/app/helpers/send_currency_job_helper.rb:52:in `perform'
Jun  5 15:32:37 ip-10-189-97-151 tapjoyserver-jobs[1]: [2019-06-05 15:32:37 +0000 (1786)] INFO : Running job NonManagedSendCurrencyJob with params {"class"=>"NonManagedSendCurrencyJob", "args"=>["09d3fd0a-5736-4b25-8535-1f63675f0a4b"]}
```