### PR TITLE
[no-jira] cache the queue visibility timeout rather than access the api twice

### DIFF
--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -70,8 +70,8 @@ module Chore
           msg = queue.receive_messages(:limit => sqs_polling_amount, :attributes => [:receive_count])
           messages = *msg
           messages.each do |message|
-            unless duplicate_message?(message.id, message.queue.url, message.queue.visibility_timeout)
-              block.call(message.handle, queue_name, message.queue.visibility_timeout, message.body, message.receive_count - 1)
+            unless duplicate_message?(message.id, message.queue.url, queue_timeout)
+              block.call(message.handle, queue_name, queue_timeout, message.body, message.receive_count - 1)
             end
             Chore.run_hooks_for(:on_fetch, message.handle, message.body)
           end

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -2,7 +2,7 @@ module Chore
   module Version #:nodoc:
     MAJOR = 3
     MINOR = 2
-    PATCH = 0
+    PATCH = 1
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')
   end


### PR DESCRIPTION
If we take a look at the `visibility_timeout` method on `queue`, we can see it calls `get_queue_attributes` https://github.com/aws/aws-sdk-ruby/blob/aws-sdk-v1/lib/aws/sqs/queue.rb#L783 every time, which calls out to the API (https://docs.aws.amazon.com/AWSRubySDK/latest/AWS/SQS/Client.html#get_queue_attributes-instance_method). We only want to do this one time per consumer, not message.