### PR TITLE
[no-jira] add ability for dedupe_lambdas to return nil to skip checking

### DIFF
--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -2,7 +2,7 @@ module Chore
   module Version #:nodoc:
     MAJOR = 3
     MINOR = 2
-    PATCH = 1
+    PATCH = 2
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')
   end


### PR DESCRIPTION
This allows us to conditionally perform the secondary-deduping in chore on the dedupe-lambda results. It simply checks the results for either `nil` or an empty string, and if so, skips the deduping on the lambda.

To test this, I replaced the `UpdateLifetimeSpend` job on a tapinabox with a job that randomly returns either `nil` or a valid id for the dedupe-lambda for the purposes of testing (I really just need a pre-configured sqs queue):
```
class UpdateLifetimeSpendJob
  include Chore::Job
  queue_options name: 'v1_UpdateLifetimeSpend', :dedupe_lambda => lambda {|id|
   if rand > 0.5
    Rails.logger.info("UpdateLifetimeSpendJob: returned nil, not deduping")
    return nil
   else
    return id
   end
  }

  def perform(id)
    
  end
end
```


In the cases where the lambda returns `nil`, we expect the job to run, which it does:

```
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: [2019-06-11 14:55:09 +0000 (3523)] INFO : UpdateLifetimeSpendJob: returned nil
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: [2019-06-11 14:55:09 +0000 (3523)] INFO : UpdateLifetimeSpendJob dedupe key nil, skipping memcached lookup.
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: [2019-06-11 14:55:09 +0000 (3523)] INFO : Running job UpdateLifetimeSpendJob with params {"class"=>"UpdateLifetimeSpendJob", "args"=>["123"]}
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: I, [2019-06-11T14:55:10.270365 #3523]  INFO -- : [AWS SQS 200 0.274321 0 retries] get_queue_url(:queue_name=>"tapinabox_andrew_v1_UpdateLifetimeSpend")
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: [2019-06-11 14:55:10 +0000 (3523)] INFO : Finished job UpdateLifetimeSpendJob with params {"class"=>"UpdateLifetimeSpendJob", "args"=>["123"]}
```
Then, when the lambda returns a non-null value twice in succession, we expect it to do a normal dedupe:

```
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: [2019-06-11 14:59:18 +0000 (3523)] INFO : Running job UpdateLifetimeSpendJob with params {"class"=>"UpdateLifetimeSpendJob", "args"=>["123"]}
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: I, [2019-06-11T14:59:18.661353 #3523]  INFO -- : [AWS SQS 200 0.267185 0 retries] delete_message_batch(:entries=>[{:id=>"0",:receipt_handle=>"AQEBjPHj9XuMwimqEDUNoDJvMvZuPCFz6uV6lG6Qg18luI0yQ1KcemCxkIeS104emr8jlPz/oRNqknjXgBUnaBDOBSESBrfxbc4C5WmZ/k7uL+7IRJKQrW2kIZrAr3PVzuCLZ4T0kHDRQwPRjWvPVOO/EVAaBDEHiY9RSaySgj+FIH8Lcud4K4+i4JIUWCppGtmKkUYqVklhOnn8E5HC+C2P0ji6+4iCBrnfrCLTWMot0xWY4/ukLmfVRyzffhFINki8+4q+Ij+W7MKoLaJ32s7+G+mcUUMdS6EveBIzn5Nb/NTgIRX1IxkyRpKo4L4pRDm9hQ9R03+l7N6BdKjQR6Q/w9OvMXe9cWOCvrAJEsdO6cw/CH8w9AncwE+71uSp/lm7BzAbGTdhQySR0Kwm5Nylg6iFGvkqy6Lad2mVJRXB5Ag="}],:queue_url=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_andrew_v1_UpdateLifetimeSpend")
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]:
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: [2019-06-11 14:59:18 +0000 (3523)] INFO : Finished job UpdateLifetimeSpendJob with params {"class"=>"UpdateLifetimeSpendJob", "args"=>["123"]}
Jun 11 15:10:58 ip-10-189-36-248 tapjoyserver-jobs[1]: [2019-06-11 14:59:18 +0000 (3523)] INFO : Found and deleted duplicate job UpdateLifetimeSpendJob
```

/to @Tapjoy/dmmeas @obrie 