### PR TITLE
OPER-5336 Update AWS SDK library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@
 **Cleanups**
 - N/A
 
+## [v4.0.0](https://github.com/Tapjoy/chore/tree/v4.0.0)
+
+**Features**
+
+- AWS SDK library has been updated to support AWS authentication via
+[Web Federated Identity](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-browser-credentials-federated-id.html)
+  - The API has jumped ahead 2 major versions, so some of the internals (e.g.
+    [`Chore::UnitOfWork`](lib/chore/unit_of_work.rb)) had to be changed to accommodate its changes. In the end, however,
+    this update is designed to function as a drop-in replacement for earlier versions of Chore
+
+**Fixed bugs**
+
+- Some of the SQS specs were not actually testing output values
+
+**Cleanups**
+
+- Many more YARD docs
+- Documented the release process
+- Mild overhaul of the base README
+
 ## [v3.1.0](https://github.com/Tapjoy/chore/tree/v3.1.0) (2017-09-15)
 
 **Features**

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014, Tapjoy, Inc.
+Copyright (c) 2020, Tapjoy, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,92 +1,90 @@
-# Chore: Job processing... for the future!
+# Chore: Async Job Processing Framework For Ruby
 
 [![Build Status](https://travis-ci.org/Tapjoy/chore.svg?branch=master)](https://travis-ci.org/Tapjoy/chore)
 
 ## About
 
-Chore is a pluggable, multi-backend job processor. It was built from the ground up to be extremely flexible. We hope that you
-will find integrating and using Chore to be as pleasant as we do.
+Chore is a pluggable, multi-backend job processing framework. It was built from the ground up to be extremely flexible.
+We hope that you find integrating and using Chore to be as pleasant as we do.
 
-The full docs for Chore can always be found at http://tapjoy.github.io/chore.
+The full docs for Chore can always be found at https://tapjoy.github.io/chore.
 
 ## Configuration
 
 Chore can be integrated with any Ruby-based project by following these instructions:
 
-    gem 'chore-core', '~> 1.6.0'
+1. Add `chore-core` to the Gemfile
 
-If you also plan on using SQS, you must also bring in dalli to use for memcached:
+    ```ruby
+    gem 'chore-core', '~> 4.0.0'
+    ```
 
+    When using SQS, also add `dalli` to use for `memcached`-based deduplication:
+
+    ```ruby
     gem 'dalli'
+    ```
 
-Create a `Chorefile` file in the root of your project directory. While you can configure Chore itself from this file, it's primarly used to direct the Chore binary toward the root of your application, so that it can locate all of the depdendencies and required code.
+1. Create a `Chorefile` file in the root of the project directory. While Chore itself can be configured from this file,
+it's primarily used to direct the Chore binstub toward the root of the application so that it can locate all of the
+dependencies and required code.
 
+    ```
     --require=./<FILE_TO_LOAD>
+    ```
 
-Make sure that `--require` points to the main entry point for your app. If integrating with a Rails app, just point it to the directory of your application and it will handle loading the correct files on its own.
+    Make sure that `--require` points to the main entry point for the application. If integrating with a Rails app,
+    point it to the application directory and Chore will handle loading the correct files on its own.
 
-Other options include:
+1. When using SQS, ensure that AWS credentials exist in the environment (e.g. but not limited to `AWS_ACCESS_KEY_ID` &
+`AWS_SECRET_ACCESS_KEY` environment variables) and an AWS region is set (e.g. `AWS_REGION` environment variable) so that
+Chore can authenticate with AWS.
 
-    --concurrency 16 # number of concurrent worker processes, if using forked worker strategy
-    --worker-strategy Chore::Strategy::ForkedWorkerStrategy # which worker strategy class to use
-    --consumer Chore::Queues::SQS::Consumer # which consumer class to use Options are SQS::Consumer and Filesystem::Consumer. Filesystem is recommended for local and testing purposes only.
-    --consumer-strategy Chore::Queues::Strategies::Consumer::ThreadedConsumerStrategy # which consuming strategy to use. Options are SingleConsumerStrategy and ThreadedConsumerStrategy. Threaded is recommended for better tuning your consuming profile
-    --consumer-sleep-interval 1.0 # The amount of time in seconds to sleep when a consumer doesn't receive any messages. Sub-second values are accepted. The default varies by consumer implementation. This is a weak form of backoff for when there is no work to do.
-    --threads-per-queue 4 # number of threads per queue for consuming from a given queue.
-    --dedupe-servers # if using SQS or similiar queue with at-least once delivery and your memcache is running on something other than localhost
-    --batch-size 50 # how many messages are batched together before handing them to a worker
-    --batch-timeout 20 # maximum number of seconds to wait until handing a message over to a worker
-    --queue_prefix prefixy # A prefix to prepend to queue names, mainly for development and qa testing purposes
-    --max-attempts 100 # The maximum number of times a job can be attempted
-    --dupe-on-cache-failure # Determines the deduping behavior when a cache connection error occurs. When set to `false`, the message is assumed not to be a duplicate. Defaults to `false`.
-    --queue-polling-size 10 # If your particular queueing system supports responding with messages in batches of a certain size, you can control that with this flag. SQS has a built in upper-limit of 10, but other systems will vary.
+    By default, Chore will run over all queues it detects among the required files. If different behavior is desired,
+    use one of the following flags:
 
-If you're using SQS, you'll want to add AWS keys so that Chore can authenticate with AWS.
-
-    --aws-access-key=<AWS KEY>
-    --aws-secret-key=<AWS SECRET>
-
-By default, Chore will run over all queues it detects among the required files. If you wish to change this behavior, you can use:
-
+    ```
+    # Note that only one of these options may be used, not both. Chore will quit
+    # if both options are specified.
     --queues QUEUE1,QUEUE2... # a list of queues to process
     --except-queues QUEUE1,QUEUE2... # a list of queues _not_ to process
+    ```
 
-Note that you can use one or the other but not both. Chore will quit and make fun of you if both options are specified.
+1. Chore has many more options, which can be viewed by executing `bundle exec chore --help`
 
-### Tips for configuring Chore
+### Tips For Configuring Chore
 
-For Rails, it can be necessary to add the directory you store your jobs in to the eager loading path,
-found in application.rb. You likely need a similar approach for most apps using jobs, unless you places
-them into a directory that is already eager loaded by default. One example of this might be:
+For Rails, it can be necessary to add the jobs directory to the eager loading path, found in `application.rb`. A similar
+approach for most apps using jobs is likely needed, unless the jobs are placed into a directory that is already eager
+loaded by the application. One example of this might be:
 
 ```ruby
 config.eager_load_paths += File.join(config.root, "app", "jobs")
 ```
 
-However, due to the way eager_load_paths works in Rails, this may only solve the issue
-in your production environment. You might also find it useful for other environments
-to throw soemthing like this in an config/initializers/chore.rb file, although you
-can choose to load the job files in any way you like:
+However, due to the way `eager_load_paths` works in Rails, this may only solve the issue in the production environment.
+It can also be useful useful for other environments to have something like this in an `config/initializers/chore.rb`
+file, although the job files can be loaded in just about any way.
 
 ```ruby
-Dir["#{Rails.root}/app/jobs/**/*"].each do |file|
-  require file unless File.directory?(file)
-end unless Rails.env.production?
+if !Rails.env.production?
+  Dir["#{Rails.root}/app/jobs/**/*"].each do |file|
+    require file unless File.directory?(file)
+  end
+end
 ```
 
-### Producing and Consuming Jobs
+### Producing & Consuming Jobs
 
-When it comes to configuring Chore, you have 2 main use cases - as a producer of messages, or as a consumer of messages (the consumer is also able to produce messages if need be, but is running as it's own isolated instance of your application).
+When it comes to configuring Chore, there are 2 main use configurations - as a producer of messages, or as a consumer of
+messages. The consuming context may also messages if necessary, as it is running as its own isolated instance of the
+application.
 
-For producers, you must do all of your Chore configuration in an intializer.
+For producers, all of the Chore configuration must be in an initializer.
 
-For consumers, you need to either use a Chorefile or Chorefile + an initializer.
+For consumers, a Chorefile must be used. A Chorefile _plus_ an initializer is also a good pattern.
 
-Because you are likely to use the same app as the basis for both producing and consuming messages, you'll already have a considerable amount of configuration in your Producer - it makes sense to use Chorefile to simply provide the `require` option, and stick to the initializer for the rest of the configuration to keep things DRY.
-
-However, like many aspects of Chore, it is ultimately up to the developer to decide which use case fits their needs best. Chore is happy to let you configure it in almost any way you want.
-
-An example of how to configure chore via an initializer:
+Here's example of how to configure chore via an initializer:
 
 ```ruby
 Chore.configure do |c|
@@ -99,27 +97,42 @@ Chore.configure do |c|
 end
 ```
 
+Because it is like that the same application serves as the basis for both producing and consuming messages, and there
+will already be a considerable amount of configuration in the Producer, it makes sense to use Chorefile to simply
+provide the `require` option and stick to the initializer for the rest of the configuration to keep things DRY.
+
+However, like many aspects of Chore, it is ultimately up to the developer to decide which use case fits their needs
+best. Chore is happy to be configured in almost any way a developer desires.
+
 ## Integration
 
-Add an appropriate line to your `Procfile`:
+This section assumes `foreman` is being used to execute (or export the run commands of) the application, but it is not
+ strictly necessary.
 
+1. Add an appropriate line to the `Procfile`:
+
+    ```
     jobs: bundle exec chore -c config/chore.config
+    ```
 
-If your queues do not exist, you must create them before you run the application:
+1. If the queues do not exist, they must be created before the application can produce/consume Chore jobs:
 
-```ruby
-require 'aws-sdk'
-sqs = AWS::SQS.new
-sqs.queues.create("test_queue")
-```
+    ```ruby
+    require 'aws-sdk-sqs'
+    sqs = Aws::SQS::Client.new
+    sqs.create_queue(queue_name: "test_queue")
+    ```
 
-Finally, start foreman as usual
+1. Finally, start the application as usual
 
+    ```
     bundle exec foreman start
+    ```
 
-## Chore::Job
+## `Chore::Job`
 
-A Chore::Job is any class that includes `Chore::Job` and implements `perform(*args)` Here is an example job class:
+A `Chore::Job` is any class with `include Chore::Job` and implements a `perform(*args)` instance method. Here is an
+example job class:
 
 ```ruby
 class TestJob
@@ -129,30 +142,36 @@ class TestJob
   def perform(args={})
     Chore.logger.debug "My first async job"
   end
-
 end
 ```
 
-This job declares that the name of the queue it uses is `test_queue`, set in the queue_options method.
+This job declares that the name of the queue it uses is `test_queue`, set in the `queue_options` method.
 
-### Chore::Job and perform signatures
+### `Chore::Job` & `perform` Signatures
 
-The perform method signature can have explicit argument names, but in practice this makes changing the signature more difficult later on. Once a Job is in production and is being used at a constant rate, it becomes problematic to begin mixing versions of jobs which have non-matching signatures.
+The perform method signature can have explicit argument names, but in practice this makes changing the signature more
+difficult later on. Once a `Chore::Job` is in production and being used at a constant rate, it becomes problematic to
+begin mixing versions of the job with non-matching signatures.
 
-While this is able to be overcome with a number of techniques, such as versioning your jobs/queues, it increases the complexity of making changes.
+While this is able to be overcome with a number of techniques, such as versioning jobs/queues, it increases the
+complexity of making changes.
 
-The simplest way to structure job signatures is to treat the arguments as a hash. This will allow you to maintain forwards and backwards compatibility between signature changes with the same job class.
+The simplest way to structure job signatures is to treat the arguments as a hash. This enables maintaining forwards and
+backwards compatibility between signature changes with the same job class.
 
-However, Chore is ultimately agnostic to your particular needs in this regard, and will let you use explicit arguments in your signatures as easily as you can use a simple hash - the choice is left to you, the developer.
+However, Chore is ultimately agnostic in this regard and will allow explicit arguments in signatures as easily as using
+a simple hash; the choice is left to the developer.
 
-### Chore::Job and publishing Jobs
+### `Chore::Job` & Publishing Jobs
 
-Now that you've got a test job, if you wanted to publish to that job it's as simple as:
+Now that there's a test job, publishing an instance of the job is as simple as:
+
 ```ruby
 TestJob.perform_async({"message"=>"YES, DO THAT THING."})
 ```
 
-It's advisable to specify the Publisher chore uses to send messages globally, so that you can change it easily for local and test environments. To do this, you can add a configuration block to an initializer like so:
+It's advisable to specify the Publisher Chore uses to send messages globally, so that it can easily be modified based on
+the environment. To do this, add a configuration block to an initializer:
 
 ```ruby
 Chore.configure do |c|
@@ -160,14 +179,15 @@ Chore.configure do |c|
 end
 ```
 
-It is worth noting that any option that can be set via config file or command-line args can also be set in a configure block.
+It is worth noting that any option that can be set via config file or command-line args can also be set in a configure
+block.
 
 If a global publisher is set, it can be overridden on a per-job basis by specifying the publisher in `queue_options`.
 
 ## Retry Backoff Strategy
 
-Chore has basic support for delaying retries  of a failed job using a step function. Currently the only queue that
-supports this functionality is SQS, all others will simply ignore the delay setting.
+Chore has basic support for delaying retries of a failed job using a step function. Currently the only queue that
+supports this functionality is SQS; all others will simply ignore the delay setting.
 
 ### Setup
 
@@ -179,51 +199,52 @@ queue_options :name => 'nameOfQueue',
   :backoff => lambda { |work| work.current_attempt ** 2 } # Exponential backoff
 ```
 
-### Using the Backoff
+### Using The Backoff
 
 If there is a `:backoff` option supplied, any failures will delay the next attempt by the result of that lambda.
 
-### Notes on SQS and Delays
+### Notes On SQS & Delays
 
-Read more details about SQS and Delays [here](docs/Delayed Jobs.md)
+Read more details about SQS and Delays [here](docs/Delayed%20Jobs.md)
 
 ## Hooks
 
-A number of hooks, both global and per-job, exist in Chore for your convenience.
+A number of hooks, both global and per-job, exist in Chore for flexibility and convencience. Hooks should be named
+`hook_name_identifier` where `identifier` is a descriptive string of chosen by the developer.
 
-Global Hooks:
+### Global Hooks
 
-* before_start
-* before_first_fork
-* before_fork
-* after_fork
-* around_fork
-* within_fork
-* before_shutdown
+* `before_start`
+* `before_first_fork`
+* `before_fork`
+* `after_fork`
+* `around_fork`
+* `within_fork`
+  * behaves similarly to `around_fork`, except that it is called _after_ the worker process has been forked.
+    In contrast, `around_fork` is called by the parent process ( chore-master`)
+* `before_shutdown`
 
-("within_fork" behaves similarly to around_fork, except that it is called after the worker process has been forked. In contrast, around_fork is called by the parent process.)
+## Filesystem Consumer/Publisher Hooks
 
-Filesystem Consumer/Publisher
+* `on_fetch(job_file, job_json)`
 
-* on_fetch(job_file, job_json)
+#### SQS Consumer Hooks
 
-SQS Consumer
+* `on_fetch(handle, body)`
 
-* on_fetch(handle, body)
+### Per Job
 
-Per Job:
-
-* before_publish
-* after_publish
-* before_perform(message)
-* after_perform(message)
-* on_rejected(message)
-* on_failure(message, error)
-* on_permanent_failure(queue_name, message, error)
+* `before_publish`
+* `after_publish`
+* `before_perform(message)`
+* `after_perform(message)`
+* `on_rejected(message)`
+* `on_failure(message, error)`
+* `on_permanent_failure(queue_name, message, error)`
 
 All per-job hooks can also be global hooks.
 
-Hooks can be added to a job class as so:
+Hooks can be added to a job class like so:
 
 ```ruby
 class TestJob
@@ -239,56 +260,52 @@ class TestJob
   end
 end
 ```
+
 Global hooks can also be registered like so:
 
 ```ruby
 Chore.add_hook :after_publish do
-  # your special handler here
+  # Add handler code here
 end
 ```
 
 ## Signals
 
-Signal handling can get complicated when you have multiple threads, process
-forks, and both signal handlers and application code making use of mutexes.
+Signal handling can get complicated when there are multiple threads, process forks, and both signal handlers and
+application code making use of mutexes.
 
-To simplify the complexities around this, Chore introduces some additional
-behaviors on top of Ruby's default Signal.trap implementation.  This
-functionality is primarily inspired by sidekiq's signal handling @
+To simplify the complexities around this, Chore introduces some additional behaviors on top of Ruby's default
+`Signal.trap` implementation.  This functionality is primarily inspired by `sidekiq`'s signal handling @
 https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb.
 
-In particular, Chore handles signals in a separate thread and does so
-sequentially instead of interrupt-driven.  See Chore::Signal for more details
-on the differences between Ruby's `Signal.trap` and Chore's `Chore::Signal.trap`.
+In particular Chore handles signals in a separate thread, and does so sequentially instead of being interrupt-driven.
+See `Chore::Signal` for more details on the differences between Ruby's `Signal.trap` and Chore's `Chore::Signal.trap`.
 
-Chore will respond to the following Signals:
+Chore will respond to the following signals:
 
-* INT , TERM, QUIT - Chore will begin shutting down, taking steps to safely terminate workers and not interrupt jobs in progress unless it believes they may be hung
-* USR1 - Re-opens logfiles, useful for handling log rotations
+* `INT` , `TERM`, `QUIT` - Chore will begin shutting down, taking steps to safely terminate workers and not interrupt
+  jobs in progress unless it believes they may be hung
+* `USR1` - Re-opens logfiles, useful for handling log rotations
 
 ## Timeouts
 
-When using the forked worker strategy for processing jobs, inevitably there are
-cases in which child processes become stuck.  This could result from deadlocks,
-hung network calls, tight loops, etc.  When these jobs hang, they consume
+When using the forked worker strategy for processing jobs, inevitably there are cases in which child processes become
+stuck.  This could result from deadlocks, hung network calls, tight loops, etc.  When these jobs hang, they consume
 resources and can affect throughput.
 
-To mitigate this, Chore has built-in monitoring of forked child processes.
-When a fork is created to process a batch of work, that fork is assigned an
-expiration time -- if it doesn't complete by that time, the process is sent
-a KILL signal.
+To mitigate this, Chore has built-in monitoring of forked child processes. When a fork is created to process a batch of
+work, that fork is assigned an expiration time -- if it doesn't complete by that time, the process is sent a `KILL`
+signal.
 
 Fork expiration times are determined from one of two places:
-1. The timeout associated with the queue.  For SQS, this is the visibility
-   timeout.
-2. The default queue timeout configured for Chore.  For Filesystem queues,
-   this is the value used.
 
-For example, if a worker is processing a batch of 5 jobs and each job's queue
-has a timeout of 60s, then the expiration time will be 5 minutes for the worker.
+1. The timeout associated with the queue.  For SQS queues, this is the visibility timeout.
+1. The default queue timeout configured for Chore. For filesystem queues, this is the value used.
 
-To change the default queue timeout (when one can't be inferred), you can do
-the following:
+For example, if a worker is processing a batch of 5 jobs and each job's queue has a timeout of 60s, then the expiration
+time will be 5 minutes for the worker.
+
+To change the default queue timeout (when one can't be inferred), do the following:
 
 ```ruby
 Chore.configure do |c|
@@ -296,62 +313,62 @@ Chore.configure do |c|
 end
 ```
 
-A reasonable timeout would be based on the maximum amount of time you expect any
-job in your system to run.  Keep in mind that the process running the job may
-get killed if the job is running for too long.
+A reasonable timeout would be based on the maximum amount of time any job in the system is expected to run.  Keep in
+mind that the process running the job may get killed if the job is running for too long.
 
 ## Plugins
 
-Chore has several plugin gems available, which extend it's core functionality
+Chore has several plugin gems available, which extend its core functionality
 
 [New Relic](https://github.com/Tapjoy/chore-new_relic) - Integrating Chore with New Relic
 
 [Airbrake](https://github.com/Tapjoy/chore-airbrake) - Integrating Chore with Airbrake
 
-## Managing Chore processes
+## Managing Chore Processes
 
 ### Sample Upstart
 
-There are lots of ways to create upstart scripts, so it's difficult to give a prescriptive
-example of the "right" way to do it. However, here are some ideas from how we run it in production
-at Tapjoy:
+There are lots of ways to create upstart scripts, so it's difficult to give a prescriptive example of the "right" way to
+do it. However, here are some ideas from how we run it in production at Tapjoy:
 
-You should have a specific user that the process runs under, for security reasons. Swap to
-this user at the beginning of your exec line
+For security reasons, a specific user should be specified that the process runs as. Switch to this user at the beginning
+of the exec line
 
 ```bash
 su - $USER --command '...'
 ```
 
-For the command to run Chore itself keeping all of the necessary environment variables in an env
-file that your upstart can source on it's exec line, to prevent having to mix changing environment
-variables with having to change the upstart script itself
+For the command to run Chore itself keeping all of the necessary environment variables in an env file that Upstart can
+source on it's exec line, to prevent having to mix changing environment variables with having to change the upstart
+script itself
 
 ```bash
 source $PATHTOENVVARS ;
 ```
 
-After that, you'll want to make sure you're running Chore under the right ruby version. Additionally,
-we like to redirect STDOUT and STDERR to logger, with an app name. This makes it easy to find
-information in syslog later on. Putting that all together looks like:
+After that, ensure Chore is running under the right ruby version. Additionally, `STDOUT` and `STDERR` can be redirected
+to `logger` with an app name. This makes it easy to find information in syslog later on. Putting that all together looks
+like:
 
 ```bash
 rvm use $RUBYVERSION do  bundle exec chore -c Chorefile  2>&1 | logger -t $APPNAME
 ```
 
-There are many other ways you could manage the Upstart file, but these are a few of the ways we
-prefer to do it. Putting it all together, it looks something like:
+There are many other ways to manage the Upstart file, but these are a few of the ways we prefer to do it. Putting it all
+together, it looks something like:
 
 ```bash
-exec su - special_user --command 'source /the/path/to/env ; rvm use ruby-1.9.3-p484 do bundle exec chore -c Chorefile 2>&1 | logger chore-app'
+exec su - special_user --command '\
+  source /the/path/to/env ;\
+  rvm use 2.4.1 do bundle exec chore -c Chorefile 2>&1 | logger chore-app ;'
 ```
 
 ### Locating Processes
 
-As Chore does not keep a PIDfile, and has both a master and a potential number of workers,
-you may find it difficult to isolate the exact PID for the master process.
+As Chore does not keep a PID file, and has both a master and a potential number of workers, it may be difficult to
+isolate the exact PID for the master process.
 
-To find Chore master processes via ```ps```, you can run the following:
+To find Chore master processes via `ps`, run the following:
 
 ```bash
 ps aux | grep bin/chore
@@ -366,15 +383,15 @@ pgrep -f bin/chore
 To find a list of only Chore worker processes:
 
 ```bash
-ps aux | grep chore-
+ps aux | grep chore-worker
 ```
 
 or
 
 ```bash
-pgrep -f chore-
+pgrep -f chore-worker
 ```
+
 ## Copyright
 
-Copyright (c) 2013 - 2015 Tapjoy. See LICENSE.txt for
-further details.
+Copyright (c) 2013 - 2020 Tapjoy. See [LICENSE.txt](LICENSE.txt) for further details.

--- a/chore-core.gemspec
+++ b/chore-core.gemspec
@@ -37,11 +37,10 @@ Gem::Specification.new do |s|
   s.summary = "Job processing... for the future!"
 
   s.add_runtime_dependency(%q<json>, [">= 0"])
-  s.add_runtime_dependency(%q<aws-sdk-v1>, ["~> 1.56", ">= 1.56.0"])
+  s.add_runtime_dependency(%q<aws-sdk-sqs>, ["~> 1"])
   s.add_runtime_dependency(%q<thread>, ["~> 0.1.3"])
   s.add_runtime_dependency('get_process_mem', ["~> 0.2.0"])
-  s.add_development_dependency(%q<rspec>, ["~> 3.3.0"])
+  s.add_development_dependency(%q<rspec>, ["~> 3.3"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
   s.add_development_dependency(%q<bundler>, [">= 0"])
 end
-

--- a/chore.gemspec
+++ b/chore.gemspec
@@ -37,10 +37,9 @@ Gem::Specification.new do |s|
   s.summary = "Job processing... for the future!"
 
   s.add_runtime_dependency(%q<json>, [">= 0"])
-  s.add_runtime_dependency(%q<aws-sdk-v1>, ["~> 1.56", ">= 1.56.0"])
+  s.add_runtime_dependency(%q<aws-sdk-sqs>, ["~> 1"])
   s.add_runtime_dependency(%q<thread>, ["~> 0.1.3"])
-  s.add_development_dependency(%q<rspec>, ["~> 2.12.0"])
+  s.add_development_dependency(%q<rspec>, ["~> 3.3"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
   s.add_development_dependency(%q<bundler>, [">= 0"])
 end
-

--- a/docs/Delayed Jobs.md
+++ b/docs/Delayed Jobs.md
@@ -1,28 +1,28 @@
 # Delayed Jobs, Backoffs and SQS
 
-We handle delays in SQS by changing the `VisiblityTimeout` of the in flight message. This operation is *additive*,
-meaning if you have a Queue with a default `VisiblityTimeout` of 5 minutes, the message is processed then fails 1
-minute after the message is sent, and the step function returns 60 seconds, the new `VisiblityTimeout` of the message
-will be at 5 minutes.
+We handle delays in SQS by changing the `VisibilityTimeout` of the in-flight message. This operation is *additive*,
+meaning a queue has a default `VisibilityTimeout` of 5 minutes, the message is processed then fails 1 minute after the
+message is sent, and the step function returns 60 seconds, the new `VisibilityTimeout` of the message will be at 5
+(rather than 4) minutes.
 
-This means small steps will not behave as you might expect, unless you have a `VisiblityTimeout` of 0. However, a
-`VisiblityTimeout` of 0 would cause the message to never remain in flight and would likely break the entire world. You
-want the default `VisiblityTimeout` to be as low as possible, but not low enough that it could be waiting in a Chore
-batch when the timeout hits 0 (causing the job to process twice!).
+This means small steps will not behave as one might expect, unless `VisibilityTimeout` is set to 0. However, a
+ `VisibilityTimeout` of 0 would cause the message to never remain in flight and would likely break the entire world
+when every worker tries to work a copy of the same job. The default `VisibilityTimeout` should be set as low as possible
+given the expected execution duration of the job code, but not so low that the message might be still be waiting to be
+scheduled on a Chore worker when the timeout hits 0 (causing the job to process twice!).
 
 Something else to consider is the `RetentionPeriod` of a queue. If the `RetentionPeriod` is 1 hour, and an initial
-message continues to retry through that hour, it will suddenly disappear! That is to say: the `Retentionperiod` starts
+message continues to retry through that hour, it will suddenly disappear! That is to say: the `RetentionPeriod` starts
 counting down from the moment the message is *first* sent, and does not reset.
 
-And finally, if the queue has a `DeliveryDelay` configured any delay applied by the backoff function will be *in
-addition* to the `DeliveryDelay` when the message is removed from its "in flight" status.
+Finally, if the queue has a `DeliveryDelay` configured any delay applied by the backoff function will be *in addition*
+to the `DeliveryDelay` when the message is removed from its "in flight" status.
 
 All of this should be taken into consideration when using this feature. In general, any queue requiring this will likely
 need to run as its own Facet and not share workers with other queues.
 
 ### Further Reading
 
- * [Expanded Documentation](docs/Delayed Jobs.md)
- * [SQS VisiblityTimeout](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html)
- * [SQS Delay Queues](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-delay-queues.html)
- * [SQS Message Lifecycle](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/MessageLifecycle.html)
+ * [SQS Message Lifecycle](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-basic-architecture.html)
+ * [SQS VisibilityTimeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
+ * [SQS Delay Queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-delay-queues.html)

--- a/docs/Releasing Chore.md
+++ b/docs/Releasing Chore.md
@@ -1,0 +1,39 @@
+# How To Release Chore
+
+## Non-Tapjoy Contributors
+
+1. Open a PR against the main branch (currently `master`) with the changes in it
+    - make sure to update the [version](../lib/chore/version.rb)!
+
+1. Tag (at least) a Tapjoy engineer for review when the PR is ready
+   (see [Contributors](https://github.com/Tapjoy/chore/graphs/contributors) page)
+
+1. Assuming the PR is accepted, a Tapjoy engineer will cut a release with the changes.
+
+## Tapjoy Engineers
+
+Once a PR has been reviewed and accepted for release
+
+1. Merge the PR into the main branch
+
+1. [Create a new GitHub Release](https://github.com/Tapjoy/chore/releases/new) based on the updated main branch and tag
+   it with the appropriate version (e.g. v4.0.0). Make sure to provide a useful title (PR title, for example) and
+   description.
+
+    A new release should subsequently show up in the GitHub [Releases](https://github.com/Tapjoy/chore/releases) page
+
+1. Generate and publish YARD documentation
+
+    ```
+    bundle exec rake yard
+    bundle exec rake yard:publish
+    ```
+
+    The [Chore Github Pages](https://tapjoy.github.io/chore) site should be updated with the updated documentation.
+
+1. Build and publish the new gem to RubyGems
+
+    ```
+    gem build chore-core.gemspec
+    gem push chore-core-${GEM_VERSION}.gem
+    ```

--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -63,6 +63,24 @@ module Chore #:nodoc:
     end
   end
 
+  def self.log_level_to_sym
+    return self.config[:log_level] if self.config[:log_level].is_a?(Symbol)
+    case self.config[:log_level]
+    when 0
+      :debug
+    when 1
+      :info
+    when 2
+      :warn
+    when 3
+      :error
+    when 4
+      :fatal
+    else
+      :unknown
+    end
+  end
+
   # Reopens any open files.  This will match any logfile that was opened by Chore,
   # Rails, or any other library.
   def self.reopen_logs

--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -218,6 +218,8 @@ module Chore #:nodoc:
   end
 
   # List of queue_names as configured via Chore::Job including their prefix, if set.
+  #
+  # @return [Array<String>]
   def self.prefixed_queue_names
     Chore::Job.job_classes.collect {|klass| c = constantize(klass); c.prefixed_queue_name}
   end

--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -92,8 +92,8 @@ module Chore #:nodoc:
       validate_strategy!
     end
 
-
     private
+
     def setup_options #:nodoc:
       register_option "queues", "-q", "--queues QUEUE1,QUEUE2", "Names of queues to process (default: all known)" do |arg|
         # This will remove duplicates. We ultimately force this to be a Set further below
@@ -289,4 +289,3 @@ module Chore #:nodoc:
     end
   end
 end
-

--- a/lib/chore/configuration.rb
+++ b/lib/chore/configuration.rb
@@ -1,6 +1,6 @@
 module Chore
   # Wrapper around an OpenStruct to define configuration data
-  # (TODO): Add required opts, and validate that they're set
+  # TODO: Add required opts, and validate that they're set
   class Configuration < OpenStruct
     # Helper method to make merging Hashes into OpenStructs easier
     def merge_hash(hsh={})

--- a/lib/chore/consumer.rb
+++ b/lib/chore/consumer.rb
@@ -10,9 +10,6 @@ module Chore
 
     attr_accessor :queue_name
 
-    # Raise this exception if your message has been processed but you can't delete it from the queue.
-    class CouldNotComplete < Exception; end
-
     # @param [String] queue_name Name of queue to be consumed from
     # @param [Hash] opts
     def initialize(queue_name, opts={})
@@ -29,7 +26,7 @@ module Chore
     # |message_id,message_body| where message_id is any object that the
     # consumer will need to be able to act on a message later (reject, complete, etc)
     #
-    # @param [Proc] &handler Message handler, used by the calling context (worker) to create & assigns a UnitOfWork
+    # @param [Block] &handler Message handler, used by the calling context (worker) to create & assigns a UnitOfWork
     def consume(&handler)
       raise NotImplementedError
     end
@@ -42,14 +39,15 @@ module Chore
       raise NotImplementedError
     end
 
-    # Complete should mark a message as finished. It takes a message_id as returned via consume
-    def complete(message_id)
+    # Complete should mark a message as finished.
+    #
+    # @param [String] message_id Unique ID of the message
+    # @param [Hash] receipt_handle Unique ID of the consuming transaction in non-filesystem implementations
+    def complete(message_id, receipt_handle)
       raise NotImplementedError
     end
 
     # Perform any shutdown behavior and stop consuming messages
-    #
-    # @return [FalseClass]
     def stop
       @running = false
     end
@@ -93,7 +91,7 @@ module Chore
     # hook will be invoked per message. This block call provides data necessary for the worker (calling context) to
     # populate a UnitOfWork struct.
     #
-    # @param [Proc] &handler Message handler, passed along by #consume
+    # @param [Block] &handler Message handler, passed along by #consume
     def handle_messages(&handler)
       raise NotImplementedError
     end

--- a/lib/chore/job.rb
+++ b/lib/chore/job.rb
@@ -105,6 +105,8 @@ module Chore
       end
 
       # The name of the configured queue, combined with an optional prefix
+      #
+      # @return [String]
       def prefixed_queue_name
         "#{Chore.config.queue_prefix}#{self.options[:name]}"
       end

--- a/lib/chore/publisher.rb
+++ b/lib/chore/publisher.rb
@@ -1,26 +1,42 @@
 module Chore
-  # Base class for Chore Publishers. Provides the bare interface one needs to adhere to when writing custom publishers
+  # Base class for a Chore Publisher. Provides the interface that a Chore::Publisher implementation should adhere to.
   class Publisher
     DEFAULT_OPTIONS = { :encoder => Encoder::JsonEncoder }
 
     attr_accessor :options
 
+    # @param [Hash] opts
     def initialize(opts={})
       self.options = DEFAULT_OPTIONS.merge(opts)
     end
 
     # Publishes the provided +job+ to the queue identified by the +queue_name+. Not designed to be used directly, this
     # method ferries to the publish method on an instance of your configured Publisher.
+    #
+    # @param [String] queue_name Name of queue to be consumed from
+    # @param [Hash] job Job instance definition, will be encoded to JSON
     def self.publish(queue_name,job)
       self.new.publish(queue_name,job)
     end
 
-    # Raises a NotImplementedError. This method should be overridden in your descendent, custom publisher class
+    # Publishes a message to queue
+    #
+    # @param [String] queue_name Name of the SQS queue
+    # @param [Hash] job Job instance definition, will be encoded to JSON
     def publish(queue_name,job)
       raise NotImplementedError
     end
+
+    # Sets a flag that instructs the publisher to reset the connection the next time it's used.
+    # Should be overriden in publishers (but is not required)
+    def self.reset_connection!
+    end
+
   protected
 
+    # Encodes the job class to format provided by endoder implementation
+    #
+    # @param [Any] job
     def encode_job(job)
       options[:encoder].encode(job)
     end

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -15,12 +15,12 @@ module Chore
       # Once complete job files are deleted.
       # If rejected they are moved back into new and will be processed again.  This may not be the
       # desired behavior long term and we may want to add configuration to this class to allow more
-      # creating failure handling and retrying. 
+      # creating failure handling and retrying.
       class Consumer < Chore::Consumer
         extend FilesystemQueue
 
         Chore::CLI.register_option 'fs_queue_root', '--fs-queue-root DIRECTORY', 'Root directory for fs based queue'
-        
+
         class << self
           # Cleans up expired in-progress files by making them new again.
           def cleanup(expiration_time, new_dir, in_progress_dir)
@@ -51,7 +51,7 @@ module Chore
 
             # If the file is non-zero, this means it was successfully written to
             # by a publisher and we can attempt to move it to "in progress".
-            # 
+            #
             # There is a small window of time where the file can be zero, but
             # the publisher hasn't finished writing to the file yet.
             if !File.zero?(from)
@@ -68,7 +68,7 @@ module Chore
               # The file is empty (zero bytes) and enough time has passed since
               # the file was written that we can safely assume it will never
               # get written to be the publisher.
-              # 
+              #
               # The scenario where this happens is when the publisher created
               # the file, but the process was killed before it had a chance to
               # actually write the data.
@@ -114,7 +114,7 @@ module Chore
 
         # The minimum number of seconds to allow to pass between checks for expired
         # jobs on the filesystem.
-        # 
+        #
         # Since queue times are measured on the order of seconds, 1 second is the
         # smallest duration.  It also prevents us from burning a lot of CPU looking
         # at expired jobs when the consumer sleep interval is less than 1 second.
@@ -186,7 +186,8 @@ module Chore
             job_json = File.read(in_progress_path)
             basename, previous_attempts, * = self.class.file_info(job_file)
 
-            # job_file is just the name which is the job id
+            # job_file is just the name which is the job id. 2nd argument (:receipt_handle) is nil because the
+            # filesystem is dealt with directly, as opposed to being an external API
             block.call(job_file, queue_name, queue_timeout, job_json, previous_attempts)
             Chore.run_hooks_for(:on_fetch, job_file, job_json)
           end
@@ -203,4 +204,3 @@ module Chore
     end
   end
 end
-

--- a/lib/chore/queues/filesystem/publisher.rb
+++ b/lib/chore/queues/filesystem/publisher.rb
@@ -11,7 +11,7 @@ module Chore
         include FilesystemQueue
 
         # use of mutex and file locking should make this both threadsafe and safe for multiple
-        # processes to use the same queue directory simultaneously. 
+        # processes to use the same queue directory simultaneously.
         def publish(queue_name,job)
           # First try encoding the job to avoid writing empty job files if this fails
           encoded_job = encode_job(job)

--- a/lib/chore/queues/sqs.rb
+++ b/lib/chore/queues/sqs.rb
@@ -1,6 +1,10 @@
 module Chore
   module Queues
     module SQS
+      def self.sqs_client
+        Aws::SQS::Client.new(logger: Chore.logger, log_level: Chore.log_level_to_sym)
+      end
+
       # Helper method to create queues based on the currently known list as provided by your configured Chore::Jobs
       # This is meant to be invoked from a rake task, and not directly.
       # These queues will be created with the default settings, which may not be ideal.
@@ -24,13 +28,11 @@ module Chore
           end
         end
 
-        #This will raise an exception if AWS has not been configured by the project making use of Chore
-        sqs_queues = AWS::SQS.new.queues
         Chore.prefixed_queue_names.each do |queue_name|
           Chore.logger.info "Chore Creating Queue: #{queue_name}"
           begin
-            sqs_queues.create(queue_name)
-          rescue AWS::SQS::Errors::QueueAlreadyExists
+            sqs_client.create_queue(queue_name: queue_name)
+          rescue Aws::SQS::Errors::QueueAlreadyExists
             Chore.logger.info "exists with different config"
           end
         end
@@ -45,13 +47,12 @@ module Chore
 
       def self.delete_queues!
         raise 'You must have atleast one Chore Job configured and loaded before attempting to create queues' unless Chore.prefixed_queue_names.length > 0
-        #This will raise an exception if AWS has not been configured by the project making use of Chore
-        sqs_queues = AWS::SQS.new.queues
+
         Chore.prefixed_queue_names.each do |queue_name|
           begin
             Chore.logger.info "Chore Deleting Queue: #{queue_name}"
-            url = sqs_queues.url_for(queue_name)
-            sqs_queues[url].delete
+            url = sqs_client.get_queue_url(queue_name: queue_name).queue_url
+            sqs_client.delete_queue(queue_url: url)
           rescue => e
             # This could fail for a few reasons - log out why it failed, then continue on
             Chore.logger.error "Deleting Queue: #{queue_name} failed because #{e}"
@@ -63,17 +64,14 @@ module Chore
 
       # Collect a list of queues that already exist
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Array<String>]
       def self.existing_queues
-        #This will raise an exception if AWS has not been configured by the project making use of Chore
-        sqs_queues = AWS::SQS.new.queues
-
         Chore.prefixed_queue_names.select do |queue_name|
           # If the NonExistentQueue exception is raised we do not care about that queue name.
           begin
-            sqs_queues.named(queue_name)
+            sqs_client.get_queue_url(queue_name: queue_name)
             true
-          rescue AWS::SQS::Errors::NonExistentQueue
+          rescue Aws::SQS::Errors::NonExistentQueue
             false
           end
         end

--- a/lib/chore/queues/sqs.rb
+++ b/lib/chore/queues/sqs.rb
@@ -5,6 +5,10 @@ module Chore
       # This is meant to be invoked from a rake task, and not directly.
       # These queues will be created with the default settings, which may not be ideal.
       # This is meant only as a convenience helper for testing, and not as a way to create production quality queues in SQS
+      #
+      # @param [TrueClass, FalseClass] halt_on_existing Raise an exception if the queue already exists
+      #
+      # @return [Array<String>]
       def self.create_queues!(halt_on_existing=false)
         raise 'You must have atleast one Chore Job configured and loaded before attempting to create queues' unless Chore.prefixed_queue_names.length > 0
 
@@ -30,11 +34,15 @@ module Chore
             Chore.logger.info "exists with different config"
           end
         end
+
         Chore.prefixed_queue_names
       end
 
       # Helper method to delete all known queues based on the list as provided by your configured Chore::Jobs
       # This is meant to be invoked from a rake task, and not directly.
+      #
+      # @return [Array<String>]
+
       def self.delete_queues!
         raise 'You must have atleast one Chore Job configured and loaded before attempting to create queues' unless Chore.prefixed_queue_names.length > 0
         #This will raise an exception if AWS has not been configured by the project making use of Chore
@@ -49,10 +57,13 @@ module Chore
             Chore.logger.error "Deleting Queue: #{queue_name} failed because #{e}"
           end
         end
+
         Chore.prefixed_queue_names
       end
 
       # Collect a list of queues that already exist
+      #
+      # @return [TrueClass, FalseClass]
       def self.existing_queues
         #This will raise an exception if AWS has not been configured by the project making use of Chore
         sqs_queues = AWS::SQS.new.queues

--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -1,8 +1,5 @@
-require 'aws/sqs'
+require 'aws-sdk-sqs'
 require 'chore/duplicate_detector'
-
-AWS.eager_autoload! AWS::Core
-AWS.eager_autoload! AWS::SQS
 
 module Chore
   module Queues
@@ -25,15 +22,13 @@ module Chore
         end
 
         # Resets the API client connection and provides @@reset_at so we know when the last time that was done
-        #
-        # @return [Array<Seahorse::Client::NetHttp::ConnectionPool>]
         def self.reset_connection!
           @@reset_at = Time.now
         end
 
         # Begins requesting messages from SQS, which will invoke the +&handler+ over each message
         #
-        # @param [Proc] &handler Message handler, used by the calling context (worker) to create & assigns a UnitOfWork
+        # @param [Block] &handler Message handler, used by the calling context (worker) to create & assigns a UnitOfWork
         #
         # @return [Array<Aws::SQS::Message>]
         def consume(&handler)
@@ -41,7 +36,7 @@ module Chore
             begin
               messages = handle_messages(&handler)
               sleep (Chore.config.consumer_sleep_interval) if messages.empty?
-            rescue AWS::SQS::Errors::NonExistentQueue => e
+            rescue Aws::SQS::Errors::NonExistentQueue => e
               Chore.logger.error "You specified a queue '#{queue_name}' that does not exist. You must create the queue before starting Chore. Shutting down..."
               raise Chore::TerribleMistake
             rescue => e
@@ -61,22 +56,23 @@ module Chore
         # Deletes the given message from the SQS queue
         #
         # @param [String] message_id Unique ID of the SQS message
-        #
-        # @return [struct<Aws::SQS::Types::DeleteMessageBatchResult>]
-          Chore.logger.debug "Completing (deleting): #{id}"
-          queue.batch_delete([id])
+        # @param [Hash] receipt_handle Receipt handle (unique per consume request) of the SQS message
+        def complete(message_id, receipt_handle)
+          Chore.logger.debug "Completing (deleting): #{message_id}"
+          queue.delete_messages(entries: [{ id: message_id, receipt_handle: receipt_handle }])
         end
 
         # Delays retry of a job by +backoff_calc+ seconds.
         #
         # @param [UnitOfWork] item Item to be delayed
-        # @param [Proc] backoff_calc Code that determines the backoff.
-        #
-        # @return [Integer]
+        # @param [Block] backoff_calc Code that determines the backoff.
         def delay(item, backoff_calc)
           delay = backoff_calc.call(item)
           Chore.logger.debug "Delaying #{item.id} by #{delay} seconds"
-          queue.batch_change_visibility(delay, [item.id])
+
+          queue.change_message_visibility_batch(entries: [
+            { id: item.id, receipt_handle: item.receipt_handle, visibility_timeout: delay },
+          ])
 
           return delay
         end
@@ -86,18 +82,18 @@ module Chore
         # Requests messages from SQS, and invokes the provided +&block+ over each one. Afterwards, the :on_fetch
         # hook will be invoked, per message
         #
-        # @param [Proc] &handler Message handler, passed along by #consume
+        # @param [Block] &handler Message handler, passed along by #consume
         #
         # @return [Array<Aws::SQS::Message>]
         def handle_messages(&block)
-          msg = queue.receive_messages(:limit => sqs_polling_amount, :attributes => [:receive_count])
+          msg = queue.receive_messages(:max_number_of_messages => sqs_polling_amount, :attribute_names => ['ApproximateReceiveCount'])
           messages = *msg
 
           messages.each do |message|
-            unless duplicate_message?(message.id, message.queue.url, queue_timeout)
-              block.call(message.handle, queue_name, queue_timeout, message.body, message.receive_count - 1)
+            unless duplicate_message?(message.message_id, message.queue_url, queue_timeout)
+              block.call(message.message_id, message.receipt_handle, queue_name, queue_timeout, message.body, message.attributes['ApproximateReceiveCount'].to_i - 1)
             end
-            Chore.run_hooks_for(:on_fetch, message.handle, message.body)
+            Chore.run_hooks_for(:on_fetch, message.receipt_handle, message.body)
           end
 
           messages
@@ -111,31 +107,28 @@ module Chore
         # @return [Aws::SQS::Queue]
         def queue
           if !@sqs_last_connected || (@@reset_at && @@reset_at >= @sqs_last_connected)
-            AWS::Core::Http::ConnectionPool.pools.each do |p|
-              p.empty!
-            end
+            Aws.empty_connection_pools!
             @sqs = nil
             @sqs_last_connected = Time.now
             @queue = nil
           end
-          @queue_url ||= sqs.queues.url_for(@queue_name)
-          @queue ||= sqs.queues[@queue_url]
+
+          @queue_url ||= sqs.get_queue_url(queue_name: @queue_name).queue_url
+          @queue ||= Aws::SQS::Queue.new(url: @queue_url, client: sqs)
         end
 
         # The visibility timeout (in seconds) of the queue
         #
         # @return [Integer]
         def queue_timeout
-          @queue_timeout ||= queue.visibility_timeout
+          @queue_timeout ||= queue.attributes['VisibilityTimeout'].to_i
         end
 
         # SQS API client object
         #
         # @return [Aws::SQS::Client]
         def sqs
-          @sqs ||= AWS::SQS.new(
-            :access_key_id => Chore.config.aws_access_key,
-            :secret_access_key => Chore.config.aws_secret_key)
+          @sqs ||= Chore::Queues::SQS.sqs_client
         end
 
         # Maximum number of messages to retrieve on each request

--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -17,18 +17,25 @@ module Chore
         Chore::CLI.register_option 'aws_secret_key', '--aws-secret-key KEY', 'Valid AWS Secret Key'
         Chore::CLI.register_option 'dedupe_servers', '--dedupe-servers SERVERS', 'List of mememcache compatible server(s) to use for storing SQS Message Dedupe cache'
 
+        # @param [String] queue_name Name of SQS queue
+        # @param [Hash] opts Options
         def initialize(queue_name, opts={})
           super(queue_name, opts)
-
           raise Chore::TerribleMistake, "Cannot specify a queue polling size greater than 10" if sqs_polling_amount > 10
         end
 
-        # Sets a flag that instructs the publisher to reset the connection the next time it's used
+        # Resets the API client connection and provides @@reset_at so we know when the last time that was done
+        #
+        # @return [Array<Seahorse::Client::NetHttp::ConnectionPool>]
         def self.reset_connection!
           @@reset_at = Time.now
         end
 
         # Begins requesting messages from SQS, which will invoke the +&handler+ over each message
+        #
+        # @param [Proc] &handler Message handler, used by the calling context (worker) to create & assigns a UnitOfWork
+        #
+        # @return [Array<Aws::SQS::Message>]
         def consume(&handler)
           while running?
             begin
@@ -43,17 +50,29 @@ module Chore
           end
         end
 
-        # Rejects the given message from SQS by +id+. Currently a noop
-        def reject(id)
-
+        # Unimplemented. Rejects the given message from SQS.
+        #
+        # @param [String] message_id Unique ID of the SQS message
+        #
+        # @return nil
+        def reject(message_id)
         end
 
-        # Deletes the given message from SQS by +id+
-        def complete(id)
+        # Deletes the given message from the SQS queue
+        #
+        # @param [String] message_id Unique ID of the SQS message
+        #
+        # @return [struct<Aws::SQS::Types::DeleteMessageBatchResult>]
           Chore.logger.debug "Completing (deleting): #{id}"
           queue.batch_delete([id])
         end
 
+        # Delays retry of a job by +backoff_calc+ seconds.
+        #
+        # @param [UnitOfWork] item Item to be delayed
+        # @param [Proc] backoff_calc Code that determines the backoff.
+        #
+        # @return [Integer]
         def delay(item, backoff_calc)
           delay = backoff_calc.call(item)
           Chore.logger.debug "Delaying #{item.id} by #{delay} seconds"
@@ -66,21 +85,30 @@ module Chore
 
         # Requests messages from SQS, and invokes the provided +&block+ over each one. Afterwards, the :on_fetch
         # hook will be invoked, per message
+        #
+        # @param [Proc] &handler Message handler, passed along by #consume
+        #
+        # @return [Array<Aws::SQS::Message>]
         def handle_messages(&block)
           msg = queue.receive_messages(:limit => sqs_polling_amount, :attributes => [:receive_count])
           messages = *msg
+
           messages.each do |message|
             unless duplicate_message?(message.id, message.queue.url, queue_timeout)
               block.call(message.handle, queue_name, queue_timeout, message.body, message.receive_count - 1)
             end
             Chore.run_hooks_for(:on_fetch, message.handle, message.body)
           end
+
           messages
         end
 
-        # Retrieves the SQS queue with the given +name+. The method will cache the results to prevent round trips on
-        # subsequent calls. If <tt>reset_connection!</tt> has been called, this will result in the connection being
-        # re-initialized, as well as clear any cached results from prior calls
+        # Retrieves the SQS queue object. The method will cache the results to prevent round trips on subsequent calls
+        #
+        # If <tt>reset_connection!</tt> has been called, this will result in the connection being re-initialized,
+        # as well as clear any cached results from prior calls
+        #
+        # @return [Aws::SQS::Queue]
         def queue
           if !@sqs_last_connected || (@@reset_at && @@reset_at >= @sqs_last_connected)
             AWS::Core::Http::ConnectionPool.pools.each do |p|
@@ -94,18 +122,25 @@ module Chore
           @queue ||= sqs.queues[@queue_url]
         end
 
-        # The visibility timeout of the queue for this consumer
+        # The visibility timeout (in seconds) of the queue
+        #
+        # @return [Integer]
         def queue_timeout
           @queue_timeout ||= queue.visibility_timeout
         end
 
-        # Access to the configured SQS connection object
+        # SQS API client object
+        #
+        # @return [Aws::SQS::Client]
         def sqs
           @sqs ||= AWS::SQS.new(
             :access_key_id => Chore.config.aws_access_key,
             :secret_access_key => Chore.config.aws_secret_key)
         end
 
+        # Maximum number of messages to retrieve on each request
+        #
+        # @return [Integer]
         def sqs_polling_amount
           Chore.config.queue_polling_size
         end

--- a/lib/chore/queues/sqs/publisher.rb
+++ b/lib/chore/queues/sqs/publisher.rb
@@ -3,29 +3,41 @@ require 'chore/publisher'
 module Chore
   module Queues
     module SQS
-      
       # SQS Publisher, for writing messages to SQS from Chore
       class Publisher < Chore::Publisher
         @@reset_next = true
 
+        # @param [Hash] opts Publisher options
         def initialize(opts={})
           super
           @sqs_queues = {}
           @sqs_queue_urls = {}
         end
 
-        # Takes a given Chore::Job instance +job+, and publishes it by looking up the +queue_name+.
+        # Publishes a message to an SQS queue
+        #
+        # @param [String] queue_name Name of the SQS queue
+        # @param [Hash] job Job instance definition, will be encoded to JSON
+        #
+        # @return [struct Aws::SQS::Types::SendMessageResult]
         def publish(queue_name,job)
           queue = self.queue(queue_name)
           queue.send_message(encode_job(job))
         end
 
         # Sets a flag that instructs the publisher to reset the connection the next time it's used
+        # TODO: We reset on every publish. Is this desirable? Seems like a performance problem.
+        #
+        # @return [Array<Seahorse::Client::NetHttp::ConnectionPool>]
         def self.reset_connection!
           @@reset_next = true
         end
 
-        # Access to the configured SQS connection object
+        private
+
+        # SQS API client object
+        #
+        # @return [Aws::SQS::Client]
         def sqs
           @sqs ||= AWS::SQS.new(
             :access_key_id => Chore.config.aws_access_key,
@@ -34,9 +46,14 @@ module Chore
             :log_level => :debug)
         end
 
-        # Retrieves the SQS queue with the given +name+. The method will cache the results to prevent round trips on subsequent calls
+        # Retrieves the SQS queue object. The method will cache the results to prevent round trips on subsequent calls
+        #
         # If <tt>reset_connection!</tt> has been called, this will result in the connection being re-initialized,
         # as well as clear any cached results from prior calls
+        #
+        # @param [String] name Name of SQS queue
+        #
+        # @return [Aws::SQS::Queue]
         def queue(name)
          if @@reset_next
             AWS::Core::Http::ConnectionPool.pools.each do |p|

--- a/lib/chore/strategies/consumer/batcher.rb
+++ b/lib/chore/strategies/consumer/batcher.rb
@@ -15,17 +15,17 @@ module Chore
         @running = true
       end
 
-      # The main entry point of the Batcher, <tt>schedule</tt> begins a thread with the provided +batch_timeout+ 
-      # as the only argument. While the Batcher is running, it will attempt to check if either the batch is full, 
+      # The main entry point of the Batcher, <tt>schedule</tt> begins a thread with the provided +batch_timeout+
+      # as the only argument. While the Batcher is running, it will attempt to check if either the batch is full,
       # or if the +batch_timeout+ has elapsed since the oldest message was added. If either case is true, the
       # items in the batch will be executed.
-      # 
+      #
       # Calling <tt>stop</tt> will cause the thread to finish it's current check, and exit
       def schedule(batch_timeout)
         @thread = Thread.new(batch_timeout) do |timeout|
-          Chore.logger.info "Batching timeout thread starting"
+          Chore.logger.info "Batching thread starting with #{batch_timeout} second timeout"
           while @running do
-            begin 
+            begin
               oldest_item = @batch.first
               timestamp = oldest_item && oldest_item.created_at
               Chore.logger.debug "Oldest message in batch: #{timestamp}, size: #{@batch.size}"
@@ -33,7 +33,7 @@ module Chore
                 Chore.logger.debug "Batching timeout reached (#{timestamp + timeout}), current size: #{@batch.size}"
                 self.execute(true)
               end
-              sleep(1) 
+              sleep(1)
             rescue => e
               Chore.logger.error "Batcher#schedule raised an exception: #{e.inspect}"
             end

--- a/lib/chore/strategies/consumer/single_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/single_consumer_strategy.rb
@@ -10,13 +10,15 @@ module Chore
       end
 
       # Begins fetching from the configured queue by way of the configured Consumer. This can only be used if you have a
-      # single queue which can be kept up with at a relatively low volume. If you have more than a single queue configured,
-      # it will raise an exception.
+      # single queue which can be kept up with at a relatively low volume. If you have more than a single queue
+      # configured, it will raise an exception.
+      #
+      # @return [TrueClass, FalseClass]
       def fetch
         Chore.logger.debug "Starting up consumer strategy: #{self.class.name}"
         queues = Chore.config.queues
         raise "When using SingleConsumerStrategy only one queue can be defined. Queues: #{queues}" unless queues.size == 1
-        
+
         @consumer = Chore.config.consumer.new(queues.first)
         @consumer.consume do |id,queue_name,queue_timeout,body,previous_attempts|
           work = UnitOfWork.new(id, queue_name, queue_timeout, body, previous_attempts, @consumer)

--- a/lib/chore/strategies/consumer/single_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/single_consumer_strategy.rb
@@ -12,16 +12,14 @@ module Chore
       # Begins fetching from the configured queue by way of the configured Consumer. This can only be used if you have a
       # single queue which can be kept up with at a relatively low volume. If you have more than a single queue
       # configured, it will raise an exception.
-      #
-      # @return [TrueClass, FalseClass]
       def fetch
         Chore.logger.debug "Starting up consumer strategy: #{self.class.name}"
         queues = Chore.config.queues
         raise "When using SingleConsumerStrategy only one queue can be defined. Queues: #{queues}" unless queues.size == 1
 
         @consumer = Chore.config.consumer.new(queues.first)
-        @consumer.consume do |id,queue_name,queue_timeout,body,previous_attempts|
-          work = UnitOfWork.new(id, queue_name, queue_timeout, body, previous_attempts, @consumer)
+        @consumer.consume do |message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts|
+          work = UnitOfWork.new(message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, @consumer)
           @fetcher.manager.assign(work)
         end
       end

--- a/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
@@ -56,14 +56,14 @@ module Chore
         t = Thread.new(queue) do |tQueue|
           begin
             consumer = Chore.config.consumer.new(tQueue)
-            consumer.consume do |id, queue_name, queue_timeout, body, previous_attempts|
+            consumer.consume do |message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts|
               # Quick hack to force this thread to end it's work
               # if we're shutting down. Could be delayed due to the
               # weird sometimes-blocking nature of SQS.
               consumer.stop if !running?
               Chore.logger.debug { "Got message: #{message_id}"}
 
-              work = UnitOfWork.new(id, queue_name, queue_timeout, body, previous_attempts, consumer)
+              work = UnitOfWork.new(message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, consumer)
               Chore.run_hooks_for(:consumed_from_source, work)
               @batcher.add(work)
             end

--- a/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
@@ -23,7 +23,7 @@ module Chore
         Chore.logger.debug "Starting up consumer strategy: #{self.class.name}"
         threads = []
         Chore.config.queues.each do |queue|
-          Chore.config.threads_per_queue.times do 
+          Chore.config.threads_per_queue.times do
             if running?
               threads << start_consumer_thread(queue)
             end
@@ -32,7 +32,7 @@ module Chore
 
         threads.each(&:join)
       end
-      
+
       # If the ThreadedConsumerStrategy is currently running <tt>stop!</tt> will begin signalling it to stop
       # It will stop the batcher from forking more work, as well as set a flag which will disable it's own consuming
       # threads once they finish with their current work.
@@ -49,7 +49,7 @@ module Chore
         @running
       end
 
-      private 
+      private
       # Starts a consumer thread for polling the given +queue+.
       # If <tt>stop!<tt> is called, the threads will shut themsevles down.
       def start_consumer_thread(queue)
@@ -61,7 +61,7 @@ module Chore
               # if we're shutting down. Could be delayed due to the
               # weird sometimes-blocking nature of SQS.
               consumer.stop if !running?
-              Chore.logger.debug { "Got message: #{id}"}
+              Chore.logger.debug { "Got message: #{message_id}"}
 
               work = UnitOfWork.new(id, queue_name, queue_timeout, body, previous_attempts, consumer)
               Chore.run_hooks_for(:consumed_from_source, work)

--- a/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
@@ -100,22 +100,21 @@ module Chore
       end
 
       def create_work_units(consumer)
-        consumer.consume do |id, queue, timeout, body, previous_attempts|
-          # Note: The unit of work object contains a consumer object that when 
-          # used to consume from SQS, would have a mutex (that comes as a part 
-          # of the AWS sdk); When sending these objects across from one process 
-          # to another, we cannot send this across (becasue of the mutex). To 
+        consumer.consume do |message_id, message_receipt_handle, queue, timeout, body, previous_attempts|
+          # Note: The unit of work object contains a consumer object that when
+          # used to consume from SQS, would have a mutex (that comes as a part
+          # of the AWS sdk); When sending these objects across from one process
+          # to another, we cannot send this across (becasue of the mutex). To
           # work around this, we simply ignore the consumer object when creating
-          # the unit of work object, and when the worker recieves the work 
-          # object, it assigns it a consumer object. 
+          # the unit of work object, and when the worker recieves the work
+          # object, it assigns it a consumer object.
           # (to allow for communication back to the queue it was consumed from)
-          work = UnitOfWork.new(id, queue, timeout, body,
-                                previous_attempts)
+          work = UnitOfWork.new(message_id, message_receipt_handle, queue, timeout, body, previous_attempts)
           Chore.run_hooks_for(:consumed_from_source, work)
           @queue.push(work) if running?
           Chore.run_hooks_for(:added_to_queue, work)
         end
       end
-    end # ThrottledConsumerStrategyyeah 
+    end # ThrottledConsumerStrategy
   end
 end # Chore

--- a/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
@@ -65,7 +65,7 @@ module Chore
       end
 
       # Gives work back to the queue in case it couldn't be assigned
-      # 
+      #
       # This will go into a separate queue so that it will be prioritized
       # over other work that hasn't been attempted yet.  It also avoids
       # a deadlock where @queue is full and the master is waiting to return

--- a/lib/chore/strategies/worker/helpers/ipc.rb
+++ b/lib/chore/strategies/worker/helpers/ipc.rb
@@ -75,7 +75,7 @@ module Chore
 
       private
 
-      # TODO: do we need this as a optional param
+      # TODO: Decide if we should make this customizable via an optional param
       def socket_file
         "./prefork_worker_sock-#{Process.pid}"
       end

--- a/lib/chore/strategies/worker/helpers/ipc.rb
+++ b/lib/chore/strategies/worker/helpers/ipc.rb
@@ -75,7 +75,6 @@ module Chore
 
       private
 
-      # TODO: Decide if we should make this customizable via an optional param
       def socket_file
         "./prefork_worker_sock-#{Process.pid}"
       end

--- a/lib/chore/unit_of_work.rb
+++ b/lib/chore/unit_of_work.rb
@@ -2,13 +2,14 @@ module Chore
   # Simple class to hold job processing information.
   # Has six attributes:
   # * +:id+ The queue implementation specific identifier for this message.
+  # * +:receipt_handle+ The queue implementation specific identifier for the receipt of this message.
   # * +:queue_name+ The name of the queue the job came from
   # * +:queue_timeout+ The time (in seconds) before the job will get re-enqueued if not processed
   # * +:message+ The actual data of the message.
   # * +:previous_attempts+ The number of times the work has been attempted previously.
   # * +:consumer+ The consumer instance used to fetch this message. Most queue implementations won't need access to this, but some (RabbitMQ) will. So we
   # make sure to pass it along with each message. This instance will be used by the Worker for things like <tt>complete</tt> and </tt>reject</tt>.
-  class UnitOfWork < Struct.new(:id,:queue_name,:queue_timeout,:message,:previous_attempts,:consumer,:decoded_message, :klass)
+  class UnitOfWork < Struct.new(:id, :receipt_handle, :queue_name, :queue_timeout, :message, :previous_attempts, :consumer, :decoded_message, :klass)
     # The time at which this unit of work was created
     attr_accessor :created_at
 
@@ -19,7 +20,7 @@ module Chore
 
     # The current attempt number for the worker processing this message.
     def current_attempt
-      previous_attempts.to_i + 1
+      previous_attempts + 1
     end
   end
 end

--- a/lib/chore/unit_of_work.rb
+++ b/lib/chore/unit_of_work.rb
@@ -19,7 +19,7 @@ module Chore
 
     # The current attempt number for the worker processing this message.
     def current_attempt
-      previous_attempts + 1
+      previous_attempts.to_i + 1
     end
   end
 end

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -1,8 +1,8 @@
 module Chore
   module Version #:nodoc:
-    MAJOR = 3
-    MINOR = 2
-    PATCH = 3
+    MAJOR = 4
+    MINOR = 0
+    PATCH = 0
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')
   end

--- a/spec/chore/consumer_spec.rb
+++ b/spec/chore/consumer_spec.rb
@@ -31,6 +31,6 @@ describe Chore::Consumer do
   end
 
   it 'should not have an implemented complete method' do
-    expect { consumer.complete(message) }.to raise_error(NotImplementedError)
+    expect { consumer.complete(message, nil) }.to raise_error(NotImplementedError)
   end
 end

--- a/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
+++ b/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
@@ -121,7 +121,7 @@ describe Chore::Queues::Filesystem::Consumer do
       end
 
       it "should consume a published job and yield the job to the handler block" do
-        expect { |b| consumer.consume(&b) }.to yield_with_args(anything, 'test-queue', 60, test_job_hash.to_json, 0)
+        expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 60, test_job_hash.to_json, 0)
       end
 
       context "rejecting a job" do
@@ -136,7 +136,7 @@ describe Chore::Queues::Filesystem::Consumer do
           expect(rejected).to be true
 
           Timecop.freeze(Time.now + 61) do
-            expect { |b| consumer.consume(&b) }.to yield_with_args(anything, 'test-queue', 60, test_job_hash.to_json, 1)
+            expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 60, test_job_hash.to_json, 1)
           end
         end
       end
@@ -145,12 +145,11 @@ describe Chore::Queues::Filesystem::Consumer do
         let!(:consumer_run_for_two_messages) { allow(consumer).to receive(:running?).and_return(true, false,true,false) }
 
         it "should remove job on completion" do
-          completed = false
+
           consumer.consume do |job_id, queue_name, job_hash|
+            expect(File).to receive(:delete).with(kind_of(String))
             consumer.complete(job_id)
-            completed = true
           end
-          expect(completed).to be true
 
           expect { |b| consumer.consume(&b) }.to_not yield_control
         end
@@ -160,7 +159,7 @@ describe Chore::Queues::Filesystem::Consumer do
         let(:timeout) { 30 }
 
         it "should consume a published job and yield the job to the handler block" do
-          expect { |b| consumer.consume(&b) }.to yield_with_args(anything, 'test-queue', 30, test_job_hash.to_json, 0)
+          expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 30, test_job_hash.to_json, 0)
         end
       end
     end
@@ -172,4 +171,3 @@ describe Chore::Queues::Filesystem::Consumer do
     end
   end
 end
-

--- a/spec/chore/queues/sqs/consumer_spec.rb
+++ b/spec/chore/queues/sqs/consumer_spec.rb
@@ -1,131 +1,170 @@
 require 'spec_helper'
 
 describe Chore::Queues::SQS::Consumer do
-  let(:queue_name) { "test" }
-  let(:queue_url) { "test_url" }
-  let(:queues) { double("queues") }
-  let(:queue) { double("test_queue", :visibility_timeout=>10, :url=>"test_queue", :name=>"test_queue") }
+  include_context 'fake objects'
+
   let(:options) { {} }
   let(:consumer) { Chore::Queues::SQS::Consumer.new(queue_name) }
-  let(:message) { TestMessage.new("handle",queue, "message body", 1) }
-  let(:message_data) {{:id=>message.id, :queue=>message.queue.url, :visibility_timeout=>message.queue.visibility_timeout}}
-  let(:pool) { double("pool") }
-  let(:sqs) { double('AWS::SQS') }
-  let(:backoff_func) { nil }
+  let(:job) { {'class' => 'TestJob', 'args'=>[1,2,'3']} }
+  let(:backoff_func) { Proc.new { 2 + 2 } }
+
+  let(:receive_message_result) { Aws::SQS::Message::Collection.new([message], size: 1) }
+
+  let(:message) do
+      Aws::SQS::Message.new(
+      message_id: 'message id',
+      receipt_handle: "receipt_handle",
+      body: job.to_json,
+      data: job,
+      queue: queue,
+      queue_url: queue_url,
+    )
+  end
+
+  # Since a message handler is required (but not validated), this convenience method lets us
+  # effectively stub the block.
+  def consume(&block)
+    block = Proc.new{} unless block_given?
+    consumer.consume(&block)
+  end
 
   before do
-    allow(AWS::SQS).to receive(:new).and_return(sqs)
-    allow(sqs).to receive(:queues) { queues }
-
-    allow(queues).to receive(:url_for) { queue_url }
-    allow(queues).to receive(:[]) { queue }
-    allow(queue).to receive(:receive_message) { message }
-    allow(pool).to receive(:empty!) { nil }
+    allow(Aws::SQS::Client).to receive(:new).and_return(sqs)
+    allow(Aws::SQS::Queue).to receive(:new).and_return(queue)
+    allow(queue).to receive(:receive_messages).and_return(receive_message_result)
+    allow(message).to receive(:attributes).and_return({ 'ApproximateReceiveCount' => rand(10) })
   end
 
   describe "consuming messages" do
-    let!(:consumer_run_for_one_message) { allow(consumer).to receive(:running?).and_return(true, false) }
-    let!(:messages_be_unique) { allow_any_instance_of(Chore::DuplicateDetector).to receive(:found_duplicate?).and_return(false) }
-    let!(:queue_contain_messages) { allow(queue).to receive(:receive_messages).and_return(message) }
-
-    it 'should configure sqs' do
-      allow(Chore.config).to receive(:aws_access_key).and_return('key')
-      allow(Chore.config).to receive(:aws_secret_key).and_return('secret')
-
-      expect(AWS::SQS).to receive(:new).with(
-        :access_key_id => 'key',
-        :secret_access_key => 'secret'
-      ).and_return(sqs)
-      consumer.consume
+    before do
+      allow(consumer).to receive(:running?).and_return(true, false)
     end
 
-    it 'should not configure sqs multiple times' do
-      allow(consumer).to receive(:running?).and_return(true, true, false)
+    context "should create objects for interacting with the SQS API" do
+      it 'should create an sqs client' do
+        expect(queue).to receive(:receive_messages)
+        consume
+      end
 
-      expect(AWS::SQS).to receive(:new).once.and_return(sqs)
-      consumer.consume
-    end
+      it "should only create an sqs client when one doesn't exist" do
+        allow(consumer).to receive(:running?).and_return(true, true, true, true, false, true, true)
+        expect(Aws::SQS::Client).to receive(:new).exactly(:once)
+        consume
+      end
 
-    it 'should look up the queue url based on the queue name' do
-      expect(queues).to receive(:url_for).with('test').and_return(queue_url)
-      consumer.consume
-    end
+      it 'should look up the queue url based on the queue name' do
+        expect(sqs).to receive(:get_queue_url).with(queue_name: queue_name)
+        consume
+      end
 
-    it 'should look up the queue based on the queue url' do
-      expect(queues).to receive(:[]).with(queue_url).and_return(queue)
-      consumer.consume
+      it 'should create a queue object' do
+        expect(consumer.send(:queue)).to_not be_nil
+        consume
+      end
     end
 
     context "should receive a message from the queue" do
-
       it 'should use the default size of 10 when no queue_polling_size is specified' do
-        expect(queue).to receive(:receive_messages).with(:limit => 10, :attributes => [:receive_count])
-        consumer.consume
+        expect(queue).to receive(:receive_messages).with(
+          :max_number_of_messages => 10,
+          :attribute_names => ['ApproximateReceiveCount']
+        ).and_return(message)
+        consume
       end
 
       it 'should respect the queue_polling_size when specified' do
         allow(Chore.config).to receive(:queue_polling_size).and_return(5)
-        expect(queue).to receive(:receive_messages).with(:limit => 5, :attributes => [:receive_count])
-        consumer.consume
+        expect(queue).to receive(:receive_messages).with(
+          :max_number_of_messages => 5,
+          :attribute_names => ['ApproximateReceiveCount']
+        )
+        consume
       end
     end
 
-    it "should check the uniqueness of the message" do
-      allow_any_instance_of(Chore::DuplicateDetector).to receive(:found_duplicate?).with(message_data).and_return(false)
-      consumer.consume
-    end
-
-    it "should yield the message to the handler block" do
-      expect { |b| consumer.consume(&b) }.to yield_with_args('handle', queue_name, 10, 'message body', 0)
-    end
-
-    it 'should not yield for a dupe message' do
-      allow_any_instance_of(Chore::DuplicateDetector).to receive(:found_duplicate?).with(message_data).and_return(true)
-      expect {|b| consumer.consume(&b) }.not_to yield_control
-    end
-
     context 'with no messages' do
-      let!(:consumer_run_for_one_message) { allow(consumer).to receive(:running?).and_return(true, true, false) }
-      let!(:queue_contain_messages) { allow(queue).to receive(:receive_messages).and_return(message, nil) }
+      before do
+        allow(consumer).to receive(:handle_messages).and_return([])
+      end
 
       it 'should sleep' do
         expect(consumer).to receive(:sleep).with(1)
-        consumer.consume
+        consume
       end
     end
 
     context 'with messages' do
-      let!(:consumer_run_for_one_message) { allow(consumer).to receive(:running?).and_return(true, true, false) }
-      let!(:queue_contain_messages) { allow(queue).to receive(:receive_messages).and_return(message, message) }
+      before do
+        allow(consumer).to receive(:duplicate_message?).and_return(false)
+        allow(queue).to receive(:receive_messages).and_return(message)
+      end
+
+      it "should check the uniqueness of the message" do
+        expect(consumer).to receive(:duplicate_message?)
+        consume
+      end
+
+      it "should yield the message to the handler block" do
+        expect { |b| consume(&b) }
+          .to yield_with_args(
+                message.message_id,
+                message.receipt_handle,
+                queue_name,
+                queue.attributes['VisibilityTimeout'].to_i,
+                message.body,
+                message.attributes['ApproximateReceiveCount'].to_i - 1
+              )
+      end
 
       it 'should not sleep' do
         expect(consumer).to_not receive(:sleep)
-        consumer.consume
+        consume
+      end
+
+      context 'with duplicates' do
+        before do
+          allow(consumer).to receive(:duplicate_message?).and_return(true)
+        end
+
+        it 'should not yield for a dupe message' do
+          expect {|b| consume(&b) }.not_to yield_control
+        end
       end
     end
   end
 
+  describe "completing work" do
+    it 'deletes the message from the queue' do
+      expect(queue).to receive(:delete_messages).with(entries: [{id: message.message_id, receipt_handle: message.receipt_handle}])
+      consumer.complete(message.message_id, message.receipt_handle)
+    end
+  end
+
   describe '#delay' do
-    let(:item) { Chore::UnitOfWork.new(message.id, message.queue, 60, message.body, 0, consumer) }
-    let(:backoff_func) { lambda { |item| 2 } }
+    let(:item) { Chore::UnitOfWork.new(message.message_id, message.receipt_handle, message.queue, 60, message.body, 0, consumer) }
+    let(:entries) do
+      [
+        { id: item.id, receipt_handle: item.receipt_handle, visibility_timeout: backoff_func.call(item) },
+      ]
+    end
 
     it 'changes the visiblity of the message' do
-      expect(queue).to receive(:batch_change_visibility).with(2, [item.id])
+      expect(queue).to receive(:change_message_visibility_batch).with(entries: entries)
       consumer.delay(item, backoff_func)
     end
   end
 
   describe '#reset_connection!' do
     it 'should reset the connection after a call to reset_connection!' do
-      expect(AWS::Core::Http::ConnectionPool).to receive(:pools).and_return([pool])
-      expect(pool).to receive(:empty!)
+      expect(Aws).to receive(:empty_connection_pools!)
       Chore::Queues::SQS::Consumer.reset_connection!
       consumer.send(:queue)
     end
 
     it 'should not reset the connection between calls' do
-      sqs = consumer.send(:queue)
-      expect(sqs).to be consumer.send(:queue)
+      expect(Aws).to receive(:empty_connection_pools!).once
+      q = consumer.send(:queue)
+      expect(consumer.send(:queue)).to be(q)
     end
 
     it 'should reconfigure sqs' do
@@ -133,13 +172,15 @@ describe Chore::Queues::SQS::Consumer do
       allow_any_instance_of(Chore::DuplicateDetector).to receive(:found_duplicate?).and_return(false)
 
       allow(queue).to receive(:receive_messages).and_return(message)
-      consumer.consume
+      allow(sqs).to receive(:receive_message).with({:attribute_names=>["ApproximateReceiveCount"], :max_number_of_messages=>10, :queue_url=>queue_url})
+
+      consume
 
       Chore::Queues::SQS::Consumer.reset_connection!
-      allow(AWS::SQS).to receive(:new).and_return(sqs)
+      allow(Aws::SQS::Client).to receive(:new).and_return(sqs)
 
       expect(consumer).to receive(:running?).and_return(true, false)
-      consumer.consume
+      consume
     end
   end
 end

--- a/spec/chore/queues/sqs/publisher_spec.rb
+++ b/spec/chore/queues/sqs/publisher_spec.rb
@@ -1,74 +1,63 @@
 require 'spec_helper'
 
-module Chore
-  describe Queues::SQS::Publisher do
-    let(:job) { {'class' => 'TestJob', 'args'=>[1,2,'3']}}
-    let(:queue_name) { 'test_queue' }
-    let(:queue_url) {"http://www.queue_url.com/test_queue"}
-    let(:queue) { double('queue', :send_message => nil) }
-    let(:sqs) do
-      double('sqs', :queues => double('queues', :named => queue, :url_for => queue_url, :[] => queue))
+describe Chore::Queues::SQS::Publisher do
+  include_context 'fake objects'
+
+  let(:publisher) { Chore::Queues::SQS::Publisher.new }
+  let(:job) { {'class' => 'TestJob', 'args'=>[1,2,'3']}}
+  let(:send_message_result) { double(Aws::SQS::Types::SendMessageResult, :data => job) }
+
+  before(:each) do
+    allow(Aws::SQS::Client).to receive(:new).and_return(sqs)
+    allow(sqs).to receive(:send_message).and_return(send_message_result)
+  end
+
+  it 'should configure sqs' do
+    expect(Aws::SQS::Client).to receive(:new)
+    publisher.publish(queue_name,job)
+  end
+
+  it 'should not create a new SQS client before every publish' do
+    expect(Aws::SQS::Client).to receive(:new).once
+    2.times { publisher.send(:queue, queue_name) }
+  end
+
+  it 'should lookup the queue when publishing' do
+    expect(sqs).to receive(:get_queue_url).with(queue_name: queue_name)
+    publisher.publish(queue_name, job)
+  end
+
+  it 'should create send an encoded message to the specified queue' do
+    expect(sqs).to receive(:send_message).with(queue_url: queue_url, message_body: job.to_json)
+    publisher.publish(queue_name,job)
+  end
+
+  it 'should lookup multiple queues if specified' do
+    second_queue_name = queue_name + '2'
+    expect(sqs).to receive(:get_queue_url).with(queue_name: queue_name)
+    expect(sqs).to receive(:get_queue_url).with(queue_name: second_queue_name)
+
+    publisher.publish(queue_name, job)
+    publisher.publish(second_queue_name, job)
+  end
+
+  it 'should only lookup a named queue once' do
+    expect(sqs).to receive(:get_queue_url).with(queue_name: queue_name).once
+    4.times { publisher.publish(queue_name, job) }
+  end
+
+  describe '#reset_connection!' do
+    it 'should empty API client connection pool after a call to reset_connection!' do
+      expect(Aws).to receive(:empty_connection_pools!)
+      Chore::Queues::SQS::Publisher.reset_connection!
+      publisher.send(:queue, queue_name)
     end
-    let(:publisher) { Queues::SQS::Publisher.new }
-    let(:pool) { double("pool") }
 
-    before(:each) do
-      AWS::SQS.stub(:new).and_return(sqs)
-    end
-
-    it 'should configure sqs' do
-      Chore.config.stub(:aws_access_key).and_return('key')
-      Chore.config.stub(:aws_secret_key).and_return('secret')
-
-      AWS::SQS.should_receive(:new).with(
-        :access_key_id => 'key',
-        :secret_access_key => 'secret',
-        :logger => Chore.logger,
-        :log_level => :debug
-      )
-      publisher.publish(queue_name,job)
-    end
-
-    it 'should create send an encoded message to the specified queue' do
-      queue.should_receive(:send_message).with(job.to_json)
-      publisher.publish(queue_name,job)
-    end
-
-    it 'should lookup the queue when publishing' do
-      sqs.queues.should_receive(:url_for).with('test_queue')
-      publisher.publish('test_queue', job)
-    end
-
-    it 'should lookup multiple queues if specified' do
-      sqs.queues.should_receive(:url_for).with('test_queue')
-      sqs.queues.should_receive(:url_for).with('test_queue2')
-      publisher.publish('test_queue', job)
-      publisher.publish('test_queue2', job)
-    end
-
-    it 'should only lookup a named queue once' do
-      sqs.queues.should_receive(:url_for).with('test_queue').once
-      2.times { publisher.publish('test_queue', job) }
-    end
-
-    describe '#reset_connection!' do
-      it 'should reset the connection after a call to reset_connection!' do
-        AWS::Core::Http::ConnectionPool.stub(:pools).and_return([pool])
-        pool.should_receive(:empty!)
-        Chore::Queues::SQS::Publisher.reset_connection!
-        publisher.queue(queue_name)
-      end
-  
-      it 'should not reset the connection between calls' do
-        sqs = publisher.queue(queue_name)
-        sqs.should be publisher.queue(queue_name)
-      end
-  
-      it 'should reconfigure sqs' do
-        Chore::Queues::SQS::Publisher.reset_connection!
-        AWS::SQS.should_receive(:new)
-        publisher.queue(queue_name)
-      end
+    # TODO: this test seems like basic identity (i.e. not even a real test)
+    it 'should not reset the connection between calls' do
+      expect(Aws).to receive(:empty_connection_pools!).once
+      Chore::Queues::SQS::Publisher.reset_connection!
+      4.times { publisher.send(:queue, queue_name ) }
     end
   end
 end

--- a/spec/chore/queues/sqs_spec.rb
+++ b/spec/chore/queues/sqs_spec.rb
@@ -1,53 +1,44 @@
 require 'spec_helper'
 
-module Chore
-  describe Queues::SQS do
-    context "when managing queues" do
-      let(:fake_sqs) {double(Object)}
-      let(:fake_queue_collection) {double(Object)}
-      let(:queue_name) {"test"}
-      let(:queue_url) {"http://amazon.sqs.url/queues/#{queue_name}"}
-      let(:fake_queue) {double(Object)}
+describe Chore::Queues::SQS do
+  include_context 'fake objects'
 
-      before(:each) do
-        allow(AWS::SQS).to receive(:new).and_return(fake_sqs)
-        allow(Chore).to receive(:prefixed_queue_names).and_return([queue_name])
-        allow(fake_queue).to receive(:delete)
+  context "when managing queues" do
+    before(:each) do
+      allow(Aws::SQS::Client).to receive(:new).and_return(sqs)
+      allow(sqs).to receive(:create_queue).and_return(queue)
+      allow(sqs).to receive(:delete_queue).and_return(Struct.new(nil))
+      allow(queue).to receive(:delete).and_return(sqs.delete_queue(queue))
+      allow(Chore).to receive(:prefixed_queue_names).and_return([queue_name])
+      allow(queue).to receive(:delete)
+    end
 
-        allow(fake_queue_collection).to receive(:[]).and_return(fake_queue)
-        allow(fake_queue_collection).to receive(:create)
-        allow(fake_queue_collection).to receive(:url_for).with(queue_name).and_return(queue_url)
+    it 'should create queues that are defined in its internal job name list' do
+      #Only one job defined in the spec suite
+      expect(sqs).to receive(:create_queue).with(queue_name: queue_name)
+      Chore::Queues::SQS.create_queues!
+    end
 
-        allow(fake_sqs).to receive(:queues).and_return(fake_queue_collection)
+    it 'should delete queues that are defined in its internal job name list' do
+      #Only one job defined in the spec suite
+      expect(sqs).to receive(:delete_queue).with(queue_url: sqs.get_queue_url.queue_url)
+      Chore::Queues::SQS.delete_queues!
+    end
+
+    context 'and checking for existing queues' do
+      it 'checks for existing queues' do
+        expect(described_class).to receive(:existing_queues).and_return([])
+        Chore::Queues::SQS.create_queues!(true)
       end
 
-      it 'should create queues that are defined in its internal job name list' do
-        #Only one job defined in the spec suite
-        expect(fake_queue_collection).to receive(:create)
-        Chore::Queues::SQS.create_queues!
+      it 'raises an error if a queue does exist' do
+        allow(described_class).to receive(:existing_queues).and_return([queue_name])
+        expect{Chore::Queues::SQS.create_queues!(true)}.to raise_error(RuntimeError)
       end
 
-      it 'should delete queues that are defined in its internal job name list' do
-        #Only one job defined in the spec suite
-        expect(fake_queue).to receive(:delete)
-        Chore::Queues::SQS.delete_queues!
-      end
-
-      context 'and checking for existing queues' do
-        it 'checks for existing queues' do
-          expect(described_class).to receive(:existing_queues).and_return([])
-          Chore::Queues::SQS.create_queues!(true)
-        end
-
-        it 'raises an error if a queue does exist' do
-          allow(described_class).to receive(:existing_queues).and_return([queue_name])
-          expect{Chore::Queues::SQS.create_queues!(true)}.to raise_error(RuntimeError)
-        end
-
-        it 'does not raise an error if a queue does not exist' do
-          allow(described_class).to receive(:existing_queues).and_return([])
-          expect{Chore::Queues::SQS.create_queues!(true)}.not_to raise_error
-        end
+      it 'does not raise an error if a queue does not exist' do
+        allow(described_class).to receive(:existing_queues).and_return([])
+        expect{Chore::Queues::SQS.create_queues!(true)}.not_to raise_error
       end
     end
   end

--- a/spec/chore/strategies/consumer/single_consumer_strategy_spec.rb
+++ b/spec/chore/strategies/consumer/single_consumer_strategy_spec.rb
@@ -11,13 +11,13 @@ describe Chore::Strategy::SingleConsumerStrategy do
     fetcher.stub(:manager) { manager }
     Chore.config.stub(:queues).and_return(test_queues)
     Chore.config.stub(:consumer).and_return(consumer)
-    
+
   end
 
   it "should consume and then assign a message" do
     consumer.should_receive(:new).with(test_queues.first).and_return(consumer)
-    consumer.should_receive(:consume).and_yield(1, 'test-queue', 60, "test", 0)
-    manager.should_receive(:assign).with(Chore::UnitOfWork.new(1, 'test-queue', 60, "test", 0, consumer))
+    consumer.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0)
+    manager.should_receive(:assign).with(Chore::UnitOfWork.new(1, nil, 'test-queue', 60, "test", 0, consumer))
     strategy.fetch
   end
 end

--- a/spec/chore/strategies/consumer/threaded_consumer_strategy_spec.rb
+++ b/spec/chore/strategies/consumer/threaded_consumer_strategy_spec.rb
@@ -29,8 +29,8 @@ describe Chore::Strategy::ThreadedConsumerStrategy do
   before(:each) do
     fetcher.stub(:consumers) { [consumer] }
     fetcher.stub(:manager) { manager }
-    Chore.configure do |c| 
-      c.queues = ['test'] 
+    Chore.configure do |c|
+      c.queues = ['test']
       c.consumer = consumer
       c.batch_size = batch_size
     end
@@ -40,7 +40,7 @@ describe Chore::Strategy::ThreadedConsumerStrategy do
     let(:batch_size) { 2 }
 
     it "should queue but not assign the message" do
-      consumer.any_instance.should_receive(:consume).and_yield(1, 'test-queue', 60, "test", 0)
+      consumer.any_instance.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0)
       strategy.fetch
       strategy.batcher.batch.size.should == 1
 
@@ -60,7 +60,7 @@ describe Chore::Strategy::ThreadedConsumerStrategy do
 
     it "should assign the batch" do
       manager.should_receive(:assign)
-      consumer.any_instance.should_receive(:consume).and_yield(1, 'test-queue', 60, "test", 0)
+      consumer.any_instance.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0)
       strategy.fetch
       strategy.batcher.batch.size.should == 0
     end
@@ -90,8 +90,8 @@ describe Chore::Strategy::ThreadedConsumerStrategy do
 
     before do
       fetcher.stub(:consumers) { [bad_consumer] }
-      Chore.configure do |c| 
-        c.queues = ['test'] 
+      Chore.configure do |c|
+        c.queues = ['test']
         c.consumer = bad_consumer
         c.batch_size = batch_size
         c.threads_per_queue = 1

--- a/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
@@ -13,6 +13,7 @@ describe Chore::Strategy::ForkedWorkerStrategy do
   let(:job) do
     Chore::UnitOfWork.new(
       SecureRandom.uuid,
+      nil,
       'test',
       job_timeout,
       Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])),
@@ -296,4 +297,3 @@ describe Chore::Strategy::ForkedWorkerStrategy do
     end
   end
 end
-

--- a/spec/chore/strategies/worker/single_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/single_worker_strategy_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Chore::Strategy::SingleWorkerStrategy do
   let(:manager) { double('Manager') }
   let(:job_timeout) { 60 }
-  let(:job) { Chore::UnitOfWork.new(SecureRandom.uuid, 'test', job_timeout, Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])), 0) }
+  let(:job) { Chore::UnitOfWork.new(SecureRandom.uuid, nil, 'test', job_timeout, Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])), 0) }
   subject       { described_class.new(manager) }
 
   describe '#stop!' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ class FakePublisher < Chore::Publisher
   end
 end
 
-TestMessage = Struct.new(:handle, :queue, :body, :receive_count) do
+TestMessage = Struct.new(:handle, :receipt_handle, :queue, :body, :receive_count) do
   def empty?
     false
   end

--- a/spec/support/queues/sqs/fake_objects.rb
+++ b/spec/support/queues/sqs/fake_objects.rb
@@ -1,0 +1,18 @@
+describe Chore::Queues::SQS do
+  RSpec.shared_context 'fake objects' do
+    let(:queue_name) { 'test_queue' }
+    let(:queue_url) { "http://amazon.sqs.url/queues/#{queue_name}" }
+
+    let(:queue) do
+      double(Aws::SQS::Queue,
+        attributes: {'VisibilityTimeout' => rand(10)}
+      )
+    end
+
+    let(:sqs) do
+      double(Aws::SQS::Client,
+        get_queue_url: double(Aws::SQS::Types::GetQueueUrlResult, :queue_url => queue_url),
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the AWS SDK to a modern version with support for authentication via [Web Federated Identity](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-browser-credentials-federated-id.html). While is designed to be a drop-in replacement for applications that already use Chore, there are various API changes in the AWS SDK, some of which have necessitated API changes in `Chore::Queues`. Hence I have incremented the major version of the gem.

Along the way I have made a bunch of QOL updates to the documentation. Hopefully people will find them useful :)

## Chore API Changes

### Minor Changes

1. `Chore::Consumer#consume` signature has been unified between interface and implementations
1. `Chore::Consumer#handle_jobs` renamed to `Chore::Consumer::#handle_messages` to unify names between publisher and consumer interfaces
1. `Chore::Consumer#handle_messages` private method used in all consumers has been added to the interface definition
1. `Chore::Publisher#reset_connection!` added to interface definition
1. `Chore::Consumer`-s and `Chore::Publisher`-s unified to use `message_id` argument name rather than `id` where applicable

### Major Changes

1. `UnitOfWork` now takes `:receipt_handle` argument to accommodate AWS SDK requirements
    - this is passed in as `nil` in the filesystem handler, which doesn't need it
1. SQS client object is now allocated in the parent `Chore::Queues::SQS` module rather than being duplicated in the publisher and consumer classes
1. `Chore::Queues::Consumer#complete` signature now takes an options hash to accommodate changes needed by the SQS consumer
1. `Chore::Queues::SQS::Consumer#complete` now requires the SQS message receipt handle to be passed in the options hash
1. API interactions with SQS queues have been refactored to accommodate changes in the AWS SDK APIs

## Spec Changes

1. We're now sharing fake objects between all the SQS specs
1. We're now `double`-ing the actual AWS API objects rather than generically named doubles
    - Perhaps this is incorrect? I'm not well-versed on this stuff so definitely let me know!
1. Incorrect usage of `expect(thing).to receive(:action).and_return(expected_value)` has been fixed
   - This was confusing for me, and I learned that `and_return` is actually a _mock_ being _set_ rather than an expected _value_ to be _compared_ against
1. A couple of seemingly useless specs that weren't actually testing anything have been disabled and may yet be removed in this PR, pending feedback.

## Quality Of Life Changes

1. Many more YARD docs
1. Documented the release process
