### PR TITLE
Remove appended underscore from CLI `--queue-prefix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@
 **Cleanups**
 - N/A
 
+## [v4.1.0](https://github.com/Tapjoy/chore/tree/v4.1.0)
+
+**BREAKING**
+
+This change requires changes if you are using `--queue-prefix` argument when running the `bin/chore.rb` binstub. See bug
+fix details for more info.
+
+**Fixed bugs**
+
+- `Chore::CLI` was appending an underscore to any passed in `--queue_prefix`. This should be handled by the consuming
+  application, and has been removed.
+
 ## [v4.0.0](https://github.com/Tapjoy/chore/tree/v4.0.0)
 
 **Features**

--- a/lib/chore/cli.rb
+++ b/lib/chore/cli.rb
@@ -118,7 +118,7 @@ module Chore #:nodoc:
       register_option 'num_workers', '--concurrency NUM', Integer, 'Number of workers to run concurrently'
 
       register_option 'queue_prefix', '--queue-prefix PREFIX', "Prefix to use on Queue names to prevent non-determinism in testing environments" do |arg|
-        options[:queue_prefix] = arg.downcase << "_"
+        options[:queue_prefix] = arg.downcase
       end
 
       register_option 'max_attempts', '--max-attempts NUM', Integer, 'Number of times to attempt failed jobs'

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -1,7 +1,7 @@
 module Chore
   module Version #:nodoc:
     MAJOR = 4
-    MINOR = 0
+    MINOR = 1
     PATCH = 0
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')

--- a/spec/chore/cli_spec.rb
+++ b/spec/chore/cli_spec.rb
@@ -64,13 +64,13 @@ describe Chore::CLI do
     end
 
     it 'should honor --queue-prefix when processing all queues' do
-      cli.parse(['--queue-prefix=prefixey'])
+      cli.parse(['--queue-prefix=prefixey_'])
       Chore.config.queues.should include('prefixey_test2')
     end
 
     context 'when provided duplicate queues' do
       let(:queue_options) {['--queues=test2,test2']}
-      before :each do 
+      before :each do
         cli.parse(queue_options)
       end
 
@@ -88,7 +88,7 @@ describe Chore::CLI do
     end
 
     context 'when both --queue_prefix and --queues have been provided' do
-      let(:queue_options) {['--queue-prefix=prefixy', '--queues=test2']}
+      let(:queue_options) {['--queue-prefix=prefixy_', '--queues=test2']}
       before :each do
         cli.parse(queue_options)
       end


### PR DESCRIPTION
The prefixing should be handled entirely by the consuming application, rather than Chore appending to it at the last second.

We started running into this when we (I) unified the queue prefixing logic between our application's `Chorefile` (consume) and the `Chore.config` (publish) we use in our Chore initializer. This change did not affect our production applications, because we don't use `--queue-prefix` at all in our production environments.

## Pre-Release Questions

- [x] Are we comfortable with 4.0.1 as a release version? Technically this could break people who have learned to assume the previous (imo slightly wrong) behavior
    - We'll use 4.1.0 instead.
- [x] Do we want to backport this to 3.x? If so, what's the best way to go about doing so?
    - No, we don't :)

---

Given the long history of this behavior, I am also open to _not_ doing this and instead heavily commenting the reasons why our prefixing logic differs between the Chorefile and the initializers in our applications.