### PR TITLE
Add around_publish and around_perform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 **Cleanups**
 - N/A
 
+## [v4.2.0](https://github.com/Tapjoy/chore/tree/v4.2.0)
+
+**Features**
+
+- Added Global hooks for `around_publish` with parameters queue_name, job_hash, and &blk.
+- Added Global hooks for `around_perform` with parameters klass, message, and &blk.
+
 ## [v4.1.0](https://github.com/Tapjoy/chore/tree/v4.1.0)
 
 **BREAKING**

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ A number of hooks, both global and per-job, exist in Chore for flexibility and c
 * `on_rejected(message)`
 * `on_failure(message, error)`
 * `on_permanent_failure(queue_name, message, error)`
+* `around_publish`
+* `around_perform`
 
 All per-job hooks can also be global hooks.
 
@@ -394,4 +396,4 @@ pgrep -f chore-worker
 
 ## Copyright
 
-Copyright (c) 2013 - 2020 Tapjoy. See [LICENSE.txt](LICENSE.txt) for further details.
+Copyright (c) 2013 - 2023 Tapjoy. See [LICENSE.txt](LICENSE.txt) for further details.

--- a/lib/chore/job.rb
+++ b/lib/chore/job.rb
@@ -144,7 +144,12 @@ module Chore
     def perform_async(*args)
       self.class.run_hooks_for(:before_publish,*args)
       @chore_publisher ||= self.class.options[:publisher]
-      @chore_publisher.publish(self.class.prefixed_queue_name,self.class.job_hash(args))
+
+      publish_job_hash = self.class.job_hash(args)
+      Chore.run_hooks_for(:around_publish, self.class.prefixed_queue_name, publish_job_hash) do
+        @chore_publisher.publish(self.class.prefixed_queue_name,publish_job_hash)
+      end
+
       self.class.run_hooks_for(:after_publish,*args)
     end
 

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -1,7 +1,7 @@
 module Chore
   module Version #:nodoc:
     MAJOR = 4
-    MINOR = 1
+    MINOR = 2
     PATCH = 0
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -111,7 +111,7 @@ module Chore
 
       begin
         Chore.logger.info { "Running job #{klass} with params #{message}"}
-        perform_job(klass,message)
+        perform_job(klass, message)
         item.consumer.complete(item.id, item.receipt_handle)
         Chore.logger.info { "Finished job #{klass} with params #{message}"}
         klass.run_hooks_for(:after_perform, message)
@@ -149,7 +149,9 @@ module Chore
     end
 
     def perform_job(klass, message)
-      klass.perform(*options[:payload_handler].payload(message))
+      Chore.run_hooks_for(:around_perform, klass, message) do
+        klass.perform(*options[:payload_handler].payload(message))
+      end
     end
   end
 end

--- a/spec/chore/job_spec.rb
+++ b/spec/chore/job_spec.rb
@@ -69,6 +69,14 @@ describe Chore::Job do
       Chore::Publisher.any_instance.should_receive(:publish).with('test_queue',{:class => 'TestJob',:args => args}).and_return(true)
       TestJob.perform_async(*args)
     end
+
+    it 'calls the around_publish hook with the correct parameters' do
+      args = [1,2,{:h => 'ash'}]
+      expect(Chore).to receive(:run_hooks_for).with(:around_publish, 'test_queue', {:class => 'TestJob',:args => args}).and_call_original
+      TestJob.queue_options(:publisher => Chore::Publisher)
+      Chore::Publisher.any_instance.should_receive(:publish).with('test_queue',{:class => 'TestJob',:args => args}).and_return(true)
+      TestJob.perform_async(*args)
+    end
   end
 
   describe 'publisher configured via Chore.configure' do

--- a/spec/chore/worker_spec.rb
+++ b/spec/chore/worker_spec.rb
@@ -69,6 +69,15 @@ describe Chore::Worker do
       Chore::Worker.start(work, {:payload_handler => payload_handler})
     end
 
+    it 'calls the around_perform hook with the correct parameters' do
+      expect(Chore).to receive(:run_hooks_for).with(:around_perform, SimpleJob, {"class" => 'SimpleJob', "args" => job_args}).and_call_original
+      expect(Chore).to receive(:run_hooks_for).at_least(:once).and_call_original
+
+      work = Chore::UnitOfWork.new('1', nil, 'test', 60, encoded_job, 0, consumer)
+      w = Chore::Worker.new(work, { payload_handler: payload_handler })
+      w.start
+    end
+
     context 'when the job has a dedupe_lambda defined' do
       context 'when the value being deduped on is unique' do
         let(:job_args) { [rand,2,'3'] }


### PR DESCRIPTION
add around_publish hook for workers
- wrap `@chore_publisher.publish(self.class.prefixed_queue_name,publish_job_hash)`
- allows for updating the `job_hash` (actual hash payload pushed to queue)

add around_perform hook for jobs
- wrap `perform_job(klass, message)`

## JIRA
https://tapjoy.atlassian.net/browse/DFUN-53
