### PR TITLE
SEC-2808: Add CODEOWNERS and .buginfo files

### DIFF
--- a/.buginfo
+++ b/.buginfo
@@ -1,0 +1,4 @@
+system: jira
+server: jira.unity3d.com
+project: NPE
+issuetype: Bug

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Tapjoy/eng-group-platform


### PR DESCRIPTION

https://jira.unity3d.com/browse/OSEC-2808

In order to help us integrate better with various Unity tools, we are creating `CODEOWNERS` and `.buginfo` files in all of our repositories.  You can learn more about these in the Jira ticket.

The assignments in this PR are based on assessments from this spreadsheet:

* https://docs.google.com/spreadsheets/d/1ufKQiMK4NZM-6LNfLhO-93MBDdAJXh1S6oQppiRcHkw/edit#gid=705595020

Relevant links:

* [Github team](https://github.com/orgs/Tapjoy/teams/eng-group-platform)
* [Jira project](https://jira.unity3d.com/browse/NPE)

What we're primarily looking for out of this PR review:

* Ensure that the proper team and Jira project are being assigned
* Ensure there are no syntax issues called out by github in the `CODEOWNERS` file
