### PR TITLE
[REWARDS-417] Update Dedupe Queue TTL

### DIFF
--- a/lib/chore/consumer.rb
+++ b/lib/chore/consumer.rb
@@ -73,8 +73,8 @@ module Chore
     # @param [Integer] queue_timeout
     #
     # @return [TrueClass, FalseClass]
-    def duplicate_message?(dedupe_key, klass, queue_timeout)
-      dupe_detector.found_duplicate?(:id=>dedupe_key, :queue=>klass.to_s, :visibility_timeout=>queue_timeout)
+    def duplicate_message?(dedupe_key, klass, queue_timeout, received_timestamp)
+      dupe_detector.found_duplicate?(:id=>dedupe_key, :queue=>klass.to_s, :visibility_timeout=>queue_timeout, :received_timestamp=>received_timestamp)
     end
 
     # Instance of duplicate detection implementation class

--- a/lib/chore/duplicate_detector.rb
+++ b/lib/chore/duplicate_detector.rb
@@ -5,6 +5,7 @@ module Chore
       @timeouts              = {}
       @dupe_on_cache_failure = opts.fetch(:dupe_on_cache_failure) { false }
       @timeout               = opts.fetch(:timeout) { 0 }
+      @timeout_offset        = opts.fetch(:timeout_offset) { 10 } # Default 10 seconds. Observed race condition timing (2s) with a 5x buffer.
       @dedupe_handler        = opts.fetch(:handler) do
         require 'dalli'
         client = Dalli::Client.new(opts.fetch(:servers) { nil }, {
@@ -24,9 +25,11 @@ module Chore
     # Duplicated messages will return true
     def found_duplicate?(msg_data)
       return false unless msg_data && msg_data[:queue]
-      timeout = self.queue_timeout(msg_data)
+
+      timeout = queue_timeout_with_offset(msg_data)
+
       begin
-        !@dedupe_handler.call(msg_data[:id], "1",timeout)
+        !@dedupe_handler.call(msg_data[:id], "1", timeout)
       rescue StandardError => e
         if @dupe_on_cache_failure
           Chore.logger.error "Error accessing duplicate cache server. Assuming message is a duplicate. #{e}\n#{e.backtrace * "\n"}"
@@ -43,6 +46,20 @@ module Chore
     # After that timeout, we would consider the next copy of the message received to be unique, and process it.
     def queue_timeout(msg_data)
       @timeouts[msg_data[:queue]] ||= msg_data[:visibility_timeout] || @timeout
+    end
+
+    # Retrieves the timeout for the given queue, minus some offsets
+    # to allow msgs in the dedupe cache to fully expire before the same msg is processed again.
+    def queue_timeout_with_offset(msg_data)
+      queue_timeout = self.queue_timeout(msg_data)
+      received_timestamp_offset = get_received_timestamp_offset(msg_data[:received_timestamp])
+
+      queue_timeout - received_timestamp_offset - @timeout_offset
+    end
+
+    # The time difference between when a message is Consumed and when it is Worked on
+    def get_received_timestamp_offset(received_timestamp)
+      (Time.now - received_timestamp).to_i
     end
 
   end

--- a/lib/chore/queues/filesystem/consumer.rb
+++ b/lib/chore/queues/filesystem/consumer.rb
@@ -190,10 +190,11 @@ module Chore
 
             job_json = File.read(in_progress_path)
             basename, previous_attempts, * = self.class.file_info(job_file)
+            received_timestamp = Time.now
 
             # job_file is just the name which is the job id. 2nd argument (:receipt_handle) is nil because the
             # filesystem is dealt with directly, as opposed to being an external API
-            block.call(job_file, nil, queue_name, queue_timeout, job_json, previous_attempts)
+            block.call(job_file, nil, queue_name, queue_timeout, job_json, previous_attempts, received_timestamp)
             Chore.run_hooks_for(:on_fetch, job_file, job_json)
           end
         end

--- a/lib/chore/queues/sqs/consumer.rb
+++ b/lib/chore/queues/sqs/consumer.rb
@@ -88,10 +88,11 @@ module Chore
         def handle_messages(&block)
           msg = queue.receive_messages(:max_number_of_messages => sqs_polling_amount, :attribute_names => ['ApproximateReceiveCount'])
           messages = *msg
+          received_timestamp = Time.now
 
           messages.each do |message|
-            unless duplicate_message?(message.message_id, message.queue_url, queue_timeout)
-              block.call(message.message_id, message.receipt_handle, queue_name, queue_timeout, message.body, message.attributes['ApproximateReceiveCount'].to_i - 1)
+            unless duplicate_message?(message.message_id, message.queue_url, queue_timeout, received_timestamp)
+              block.call(message.message_id, message.receipt_handle, queue_name, queue_timeout, message.body, message.attributes['ApproximateReceiveCount'].to_i - 1, received_timestamp)
             end
             Chore.run_hooks_for(:on_fetch, message.receipt_handle, message.body)
           end

--- a/lib/chore/strategies/consumer/single_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/single_consumer_strategy.rb
@@ -18,8 +18,8 @@ module Chore
         raise "When using SingleConsumerStrategy only one queue can be defined. Queues: #{queues}" unless queues.size == 1
 
         @consumer = Chore.config.consumer.new(queues.first)
-        @consumer.consume do |message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts|
-          work = UnitOfWork.new(message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, @consumer)
+        @consumer.consume do |message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, received_timestamp|
+          work = UnitOfWork.new(message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, @consumer, nil, nil, received_timestamp)
           @fetcher.manager.assign(work)
         end
       end

--- a/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/threaded_consumer_strategy.rb
@@ -56,14 +56,12 @@ module Chore
         t = Thread.new(queue) do |tQueue|
           begin
             consumer = Chore.config.consumer.new(tQueue)
-            consumer.consume do |message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts|
+            consumer.consume do |message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, received_timestamp|
               # Quick hack to force this thread to end it's work
               # if we're shutting down. Could be delayed due to the
               # weird sometimes-blocking nature of SQS.
               consumer.stop if !running?
-              Chore.logger.debug { "Got message: #{message_id}"}
-
-              work = UnitOfWork.new(message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, consumer)
+              work = UnitOfWork.new(message_id, message_receipt_handle, queue_name, queue_timeout, body, previous_attempts, consumer, nil, nil, received_timestamp)
               Chore.run_hooks_for(:consumed_from_source, work)
               @batcher.add(work)
             end

--- a/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
+++ b/lib/chore/strategies/consumer/throttled_consumer_strategy.rb
@@ -100,7 +100,7 @@ module Chore
       end
 
       def create_work_units(consumer)
-        consumer.consume do |message_id, message_receipt_handle, queue, timeout, body, previous_attempts|
+        consumer.consume do |message_id, message_receipt_handle, queue, timeout, body, previous_attempts, received_timestamp|
           # Note: The unit of work object contains a consumer object that when
           # used to consume from SQS, would have a mutex (that comes as a part
           # of the AWS sdk); When sending these objects across from one process
@@ -109,7 +109,7 @@ module Chore
           # the unit of work object, and when the worker recieves the work
           # object, it assigns it a consumer object.
           # (to allow for communication back to the queue it was consumed from)
-          work = UnitOfWork.new(message_id, message_receipt_handle, queue, timeout, body, previous_attempts)
+          work = UnitOfWork.new(message_id, message_receipt_handle, queue, timeout, body, previous_attempts, nil, nil, nil, received_timestamp)
           Chore.run_hooks_for(:consumed_from_source, work)
           @queue.push(work) if running?
           Chore.run_hooks_for(:added_to_queue, work)

--- a/lib/chore/unit_of_work.rb
+++ b/lib/chore/unit_of_work.rb
@@ -9,7 +9,7 @@ module Chore
   # * +:previous_attempts+ The number of times the work has been attempted previously.
   # * +:consumer+ The consumer instance used to fetch this message. Most queue implementations won't need access to this, but some (RabbitMQ) will. So we
   # make sure to pass it along with each message. This instance will be used by the Worker for things like <tt>complete</tt> and </tt>reject</tt>.
-  class UnitOfWork < Struct.new(:id, :receipt_handle, :queue_name, :queue_timeout, :message, :previous_attempts, :consumer, :decoded_message, :klass)
+  class UnitOfWork < Struct.new(:id, :receipt_handle, :queue_name, :queue_timeout, :message, :previous_attempts, :consumer, :decoded_message, :klass, :received_timestamp)
     # The time at which this unit of work was created
     attr_accessor :created_at
 

--- a/lib/chore/version.rb
+++ b/lib/chore/version.rb
@@ -1,7 +1,7 @@
 module Chore
   module Version #:nodoc:
     MAJOR = 4
-    MINOR = 3
+    MINOR = 4
     PATCH = 0
 
     STRING = [ MAJOR, MINOR, PATCH ].join('.')

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -53,8 +53,7 @@ module Chore
           Chore.logger.info { "#{item.klass} dedupe key nil, skipping memcached lookup." }
           return false
         end
-
-        if item.consumer.duplicate_message?(dedupe_key, item.klass, item.queue_timeout)
+        if item.consumer.duplicate_message?(dedupe_key, item.klass, item.queue_timeout, item.received_timestamp)
           Chore.logger.info { "Found and deleted duplicate job #{item.klass}"}
           item.consumer.complete(item.id, item.receipt_handle)
           return true

--- a/spec/chore/duplicate_detector_spec.rb
+++ b/spec/chore/duplicate_detector_spec.rb
@@ -21,12 +21,13 @@ describe Chore::DuplicateDetector do
   let(:dupe_on_cache_failure) { false }
   let(:dedupe_params)  { { :handler => handler, :dupe_on_cache_failure => dupe_on_cache_failure } }
   let(:dedupe) { Chore::DuplicateDetector.new(dedupe_params)}
-  let(:timeout) { 2 }
+  let(:timeout) { 20 }
+  let(:timeout_offset) { 10 }
   let(:queue_url) {"queue://bogus/url"}
   let(:queue) { double('queue', :visibility_timeout=>timeout, :url=>queue_url) }
   let(:id) { SecureRandom.uuid }
   let(:message) { double('message', :id=>id, :queue=>queue) }
-  let(:message_data) {{:id=>message.id, :visibility_timeout=>queue.visibility_timeout, :queue=>queue.url}}
+  let(:message_data) {{:id=>message.id, :visibility_timeout=>queue.visibility_timeout, :queue=>queue.url, :received_timestamp=>Time.utc(2024, 5, 10, 12, 0, 0)}}
 
   describe "#found_duplicate" do
     it 'should not return true if the message has not already been seen' do
@@ -47,8 +48,9 @@ describe Chore::DuplicateDetector do
       expect(dedupe.found_duplicate?(message_data)).to be false
     end
 
-    it "should set the timeout to be the queue's " do
-      expect(memcache).to receive(:add).with(id,"1",timeout).and_call_original
+    it "should set the timeout to be queue timeout with offset" do
+      allow(Time).to receive(:now).and_return(Time.utc(2024, 5, 10, 12, 0, 0))
+      expect(memcache).to receive(:add).with(id,"1",10).and_call_original
       expect(dedupe.found_duplicate?(message_data)).to be false
     end
 
@@ -65,6 +67,17 @@ describe Chore::DuplicateDetector do
           expect(memcache).to receive(:add).and_raise
           expect(dedupe.found_duplicate?(message_data)).to be true
         end
+      end
+    end
+  end
+
+  describe "#get_received_timestamp_offset" do
+    context 'when received_timestamp is 10 seconds before it is worked on' do
+      it "should return a 10 second offset" do
+        # Set received_timestamp_offset to 10 second offset
+        allow(Time).to receive(:now).and_return(Time.utc(2024, 5, 10, 12, 0, 10))
+
+        expect(dedupe.get_received_timestamp_offset(message_data[:received_timestamp])).to eq(10)
       end
     end
   end

--- a/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
+++ b/spec/chore/queues/filesystem/filesystem_consumer_spec.rb
@@ -114,6 +114,8 @@ describe Chore::Queues::Filesystem::Consumer do
 
   describe 'consumption' do
     let!(:consumer_run_for_one_message) { expect(consumer).to receive(:running?).and_return(true, false) }
+    let(:received_timestamp) { Time.now }
+
 
     context "founding a published job" do
       before do
@@ -121,7 +123,8 @@ describe Chore::Queues::Filesystem::Consumer do
       end
 
       it "should consume a published job and yield the job to the handler block" do
-        expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 60, test_job_hash.to_json, 0)
+        allow(Time).to receive(:now).and_return(received_timestamp)
+        expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 60, test_job_hash.to_json, 0, received_timestamp)
       end
 
       context "rejecting a job" do
@@ -136,7 +139,7 @@ describe Chore::Queues::Filesystem::Consumer do
           expect(rejected).to be true
 
           Timecop.freeze(Time.now + 61) do
-            expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 60, test_job_hash.to_json, 1)
+            expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 60, test_job_hash.to_json, 1, Time.now)
           end
         end
       end
@@ -159,7 +162,8 @@ describe Chore::Queues::Filesystem::Consumer do
         let(:timeout) { 30 }
 
         it "should consume a published job and yield the job to the handler block" do
-          expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 30, test_job_hash.to_json, 0)
+          allow(Time).to receive(:now).and_return(received_timestamp)
+          expect { |b| consumer.consume(&b) }.to yield_with_args(anything, anything, 'test-queue', 30, test_job_hash.to_json, 0, received_timestamp)
         end
       end
     end

--- a/spec/chore/queues/sqs/consumer_spec.rb
+++ b/spec/chore/queues/sqs/consumer_spec.rb
@@ -97,12 +97,15 @@ describe Chore::Queues::SQS::Consumer do
       before do
         allow(consumer).to receive(:duplicate_message?).and_return(false)
         allow(queue).to receive(:receive_messages).and_return(message)
+        allow(Time).to receive(:now).and_return(Time.utc(2024, 5, 10, 12, 0, 0))
       end
 
       it "should check the uniqueness of the message" do
         expect(consumer).to receive(:duplicate_message?)
         consume
       end
+
+      let(:received_timestamp) { Time.utc(2024, 5, 10, 12, 0, 0) }
 
       it "should yield the message to the handler block" do
         expect { |b| consume(&b) }
@@ -112,7 +115,8 @@ describe Chore::Queues::SQS::Consumer do
                 queue_name,
                 queue.attributes['VisibilityTimeout'].to_i,
                 message.body,
-                message.attributes['ApproximateReceiveCount'].to_i - 1
+                message.attributes['ApproximateReceiveCount'].to_i - 1,
+                received_timestamp
               )
       end
 

--- a/spec/chore/strategies/consumer/single_consumer_strategy_spec.rb
+++ b/spec/chore/strategies/consumer/single_consumer_strategy_spec.rb
@@ -6,6 +6,7 @@ describe Chore::Strategy::SingleConsumerStrategy do
   let(:consumer) { double("consumer") }
   let(:test_queues) { ["test-queue"] }
   let(:strategy) { Chore::Strategy::SingleConsumerStrategy.new(fetcher) }
+  let(:received_timeout) {Time.now}
 
   before do
     fetcher.stub(:manager) { manager }
@@ -15,9 +16,10 @@ describe Chore::Strategy::SingleConsumerStrategy do
   end
 
   it "should consume and then assign a message" do
+    allow(Time).to receive(:now).and_return(received_timeout)
     consumer.should_receive(:new).with(test_queues.first).and_return(consumer)
-    consumer.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0)
-    manager.should_receive(:assign).with(Chore::UnitOfWork.new(1, nil, 'test-queue', 60, "test", 0, consumer))
+    consumer.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0, received_timeout)
+    manager.should_receive(:assign).with(Chore::UnitOfWork.new(1, nil, 'test-queue', 60, "test", 0, consumer, nil, nil, received_timeout))
     strategy.fetch
   end
 end

--- a/spec/chore/strategies/consumer/threaded_consumer_strategy_spec.rb
+++ b/spec/chore/strategies/consumer/threaded_consumer_strategy_spec.rb
@@ -40,7 +40,7 @@ describe Chore::Strategy::ThreadedConsumerStrategy do
     let(:batch_size) { 2 }
 
     it "should queue but not assign the message" do
-      consumer.any_instance.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0)
+      consumer.any_instance.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0, Time.now)
       strategy.fetch
       strategy.batcher.batch.size.should == 1
 
@@ -60,7 +60,7 @@ describe Chore::Strategy::ThreadedConsumerStrategy do
 
     it "should assign the batch" do
       manager.should_receive(:assign)
-      consumer.any_instance.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0)
+      consumer.any_instance.should_receive(:consume).and_yield(1, nil, 'test-queue', 60, "test", 0, Time.now)
       strategy.fetch
       strategy.batcher.batch.size.should == 0
     end


### PR DESCRIPTION
## Context 

[REWARDS-417](https://jira.unity3d.com/projects/REWARDS/boards/926) investigation led me to Chore, the job scheduler for SQS in TJS.

After some discussion and digging, it looks like the deduplication logic is removing messages from the queue before the retention window expires. This race condition happens when we 1. consume a message and 2. add the message to the dedupe  cache with a TTL based on the SQS visibility timeout. Between 1 and 2, some time passes which can be less than a second up to 2 seconds. ([link to data](https://docs.google.com/spreadsheets/d/1vZObLyYy3uojKhDsyBqGz82g2hDysILE2RWRWMfjI_0/edit?pli=1#gid=237898670)) Sometimes the message in the dedupe cache does not expire before we see another request for the same Reward ID. This causes the message to be removed from the queue unintentionally.

## Change Log
* Created new attribute for `received_timestamp` on `UnitOfWork` that is auto populated with Time.now on creation
* In Consumer, capture `received_timestamp` and pass that in to dedupe logic
* In Worker, pass in `UnitOfWork.received_timestamp` to dedupe logic
* Changed method definitions to accept `received_timestamp`
* Added helper methods to adjust `timeout`
* Added RSpec tests on new helper methods and updated methods


## Example
**Reward ID**: 1e4651e2-9e9e-40d4-8a9d-9670d2b4996d

I greped for “`dupl`” in application.logs of the job-failures box to get Reward Ids that are duplicate and removed. We can see the job was deleted from the queue:

```
application.log.2:May 10 14:11:24 ip-172-16-9-215 tapjoyserver-jobs[1]: [2024-05-10 14:11:24 +0000 (24428)] INFO : Found duplicate job ["1e4651e2-9e9e-40d4-8a9d-9670d2b4996d", "1", 300] 

application.log.2:May 10 14:11:24 ip-172-16-9-215 tapjoyserver-jobs[1]: [2024-05-10 14:11:24 +0000 (24428)] INFO : Found and deleted duplicate job NonManagedSendCurrencyJob
```

In BQ, I searched for the same Reward ID to see the attempt history.
It tried a total of 155 times, never succeeded, and the last run time was 2024-05-10 14:06:24 UTC. 
**BQ records the last attempt at 14:06 and the job is removed at 14:11, ~5 minutes after (the retry window).**

## Changes
* Default `timeout_offset` to 10 seconds
    * The largest difference of the race condition (2 seconds) I observed, multiplied by 5.
* Update Chore Dedupe logic to take in `timeout_offset`
* Set TTL for messages added to Dedupe cache based on `queue_timeout - timeout_offset`

## Testing

Updated 6/5/2024
![image](https://github.com/Tapjoy/chore/assets/15097711/34f428bd-773f-4366-888b-5742967e4202)

### End To End Testing (TIAB)

#### Instructions
**Build the updated Chore gem**

1. Checkout debugging/logging commit of `Chore`
3. Update the `version.rb` by incrementing minor/patch (ex. 4.4.0 -> 4.4.1)
4. In the `Chore` project build the .gem file
- `gem build chore-core.gemspec` 
5. Copy the gem file from `Chore's` root folder, probably named `chore-core-<version>.gem`
6. Paste the gem file into Tapjoyserver project's folder `/vendor/cache/`
7. Update the gem in `Tapjoyservers` Gemfile to the updated version
- `gem 'chore-core', '4.4.0`

**Update TIAB with Chore gem**
1. Spin up TIAB
2. Push the TJS changes to your TIAB
- `tjsh tiab push -r`
3. SSH into your TIAB
- `ssh <first.last>@<ip_address>`
4. Install gem in the TJS directory of your TIAB
- `sudo su -`
- `cd /opt/apps/tapjoyserver/current`
- `bundle install`

**Send message to your TIABs SQS**
1.. Login to AWS as a Rewards User under Tapjoy Development
2.. Find the SQS created for your TIAB. Should be named `tapinabox_<tiab_name>_v2_SendCurrency_Failures`
3. Send a message to the SQS queue
- example can be found by polling the production SQS queue

**Verify the changes by tailing logs**
1. Tail the logs in `/opt/apps/tapjoyserver/current/logs/application.log`
2. Verify the message come in through TIAB by checking `application.log` you are tailing.
**- Verify the new TTL that is being set for the deduplicate cache**

Default Visibility timeout is 30 seconds, configured on SQS.
In each example, note the new TTL that is set.

#### Ex. 1 Pre Change (Legacy)
TTL is 30 seconds
- _30 seconds (sqs config)_
- ```[2024-06-04 20:05:32 +0000 (3951)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 54638534-e774-4838-899a-737fafb4ef34 is TTL: 30```

**Ex. 1 Full Logs**
```
### Pre Change (Legacy)
# Consumer Dupe Check
[2024-06-04 20:05:32 +0000 (3604)] INFO : >>> MANNY <Consumer.01> Dupe Check: message.id: aafc674e-088d-4531-9a13-89072350ce98, received_ts: 2024-06-04 20:05:32 +0000
  [2024-06-04 20:05:32 +0000 (3604)] INFO : >>> MANNY <Duplicate Detector.01> BEGIN
    Msg_Data: {:id=>"aafc674e-088d-4531-9a13-89072350ce98", :queue=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_manny_v2_NonManagedSendCurrency", :visibility_timeout=>30, :received_timestamp=>2024-06-04 20:05:32.825042271 +0000}
  [2024-06-04 20:05:32 +0000 (3604)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID aafc674e-088d-4531-9a13-89072350ce98 is TTL: 30
  [2024-06-04 20:05:32 +0000 (3604)] INFO : >>> MANNY <Chore Consumer.00>, Duplicate Found? false
  [2024-06-04 20:05:32 +0000 (3604)] INFO : >>> MANNY <Consumer.02> Dupe Check: No Duplicate Found
    
    # Create Unit of Work
    [2024-06-04 20:05:32 +0000 (3604)] INFO : >>> MANNY <Unit of Work.01> Created w ID:aafc674e-088d-4531-9a13-89072350ce98, Consumer , Timestamp: 2024-06-04 20:05:32 +0000
    [2024-06-04 20:05:32 +0000 (3604)] INFO : >>> MANNY <Throttled Consumer.01>, CREATED UoW: aafc674e-088d-4531-9a13-89072350ce98, TS: 2024-06-04 20:05:32 +0000
      
      # Process Unit of Work
      [2024-06-04 20:05:32 +0000 (3951)] INFO : >>> MANNY <Worker.01> Processing Item: aafc674e-088d-4531-9a13-89072350ce98, 2024-06-04 20:05:32 +0000
      
        # Worker Dupe Check
        [2024-06-04 20:05:32 +0000 (3951)] INFO : >>> MANNY <Duplicate Detector.01> BEGIN
          Msg_Data: {:id=>"54638534-e774-4838-899a-737fafb4ef34", :queue=>"NonManagedSendCurrencyJob", :visibility_timeout=>30, :received_timestamp=>2024-06-04 20:05:32.825042271 +0000}
        # IMPORTANT: Note the TTL is set to SQS' Visibility Timeout Config
        [2024-06-04 20:05:32 +0000 (3951)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 54638534-e774-4838-899a-737fafb4ef34 is TTL: 30
        [2024-06-04 20:05:32 +0000 (3951)] INFO : >>> MANNY <Chore Consumer.00>, Duplicate Found? false
      [2024-06-04 20:05:32 +0000 (3951)] INFO : >>> MANNY <Worker.03> Dupe Check: No Duplicate Found

# Errors out on TJS side (reward does not exist)
[2024-06-04 20:07:57 +0000 (3951)] ERROR : Failed to run job with error: Reward not found: 54638534-e774-4838-899a-737fafb4ef34
```

#### Ex. 2 Post Change (Updated)
TTL is 20 seconds
- _30 seconds (sqs config) - 10 seconds (timeout offset)_
- ```[2024-06-04 20:24:47 +0000 (30770)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 54638534-e774-4838-899a-737fafb4ef34 is TTL: 20```

**Ex. 2 Full Logs**
```
### Post Change (Updated)
# Consumer Dupe Check
[2024-06-04 20:24:47 +0000 (30508)] INFO : >>> MANNY <Consumer.01> Dupe Check: message.id: 57ea2b3c-4c7c-41e1-a357-645fd6b5b18c, received_ts: 2024-06-04 20:24:47 +0000
  [2024-06-04 20:24:47 +0000 (30508)] INFO : >>> MANNY <Duplicate Detector.01> BEGIN
    Msg_Data: {:id=>"57ea2b3c-4c7c-41e1-a357-645fd6b5b18c", :queue=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_manny_v2_NonManagedSendCurrency", :visibility_timeout=>30, :received_timestamp=>2024-06-04 20:24:47.496270992 +0000}
  [2024-06-04 20:24:47 +0000 (30508)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 57ea2b3c-4c7c-41e1-a357-645fd6b5b18c is TTL: 20
  [2024-06-04 20:24:47 +0000 (30508)] INFO : >>> MANNY <Chore Consumer.00>, Duplicate Found? false
  [2024-06-04 20:24:47 +0000 (30508)] INFO : >>> MANNY <Consumer.02> Dupe Check: No Duplicate Found

  # Create Unit of Work
  [2024-06-04 20:24:47 +0000 (30508)] INFO : >>> MANNY <Unit of Work.01> Created w ID:57ea2b3c-4c7c-41e1-a357-645fd6b5b18c, Consumer , Timestamp: 2024-06-04 20:24:47 +0000
  [2024-06-04 20:24:47 +0000 (30508)] INFO : >>> MANNY <Throttled Consumer.01>, CREATED UoW: 57ea2b3c-4c7c-41e1-a357-645fd6b5b18c, TS: 2024-06-04 20:24:47 +0000
    
    # Process Unit of Work
    [2024-06-04 20:24:47 +0000 (30770)] INFO : >>> MANNY <Worker.01> Processing Item: 57ea2b3c-4c7c-41e1-a357-645fd6b5b18c, 2024-06-04 20:24:47 +0000

      # Worker Dupe Check
      [2024-06-04 20:24:47 +0000 (30770)] INFO : >>> MANNY <Duplicate Detector.01> BEGIN
        Msg_Data: {:id=>"54638534-e774-4838-899a-737fafb4ef34", :queue=>"NonManagedSendCurrencyJob", :visibility_timeout=>30, :received_timestamp=>2024-06-04 20:24:47.496270992 +0000}
      # IMPORTANT: Note the TTL is set to SQS' Visibility Timeout Config
      [2024-06-04 20:24:47 +0000 (30770)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 54638534-e774-4838-899a-737fafb4ef34 is TTL: 20
      [2024-06-04 20:24:47 +0000 (30770)] INFO : >>> MANNY <Chore Consumer.00>, Duplicate Found? false
    [2024-06-04 20:24:47 +0000 (30770)] INFO : >>> MANNY <Worker.03> Dupe Check: No Duplicate Found
  
# Errors out on TJS side (reward does not exist)
[2024-06-04 20:24:47 +0000 (30770)] ERROR : Failed to run job with error: Reward not found: 54638534-e774-4838-899a-737fafb4ef34
```

#### Ex. 3 Post Change (Updated + 5 sec delay after receiving message)

TTL is 15 seconds
- _30 seconds (sqs config) - 10 seconds (timeout offset) - 5 seconds (delay offset)_
```[2024-06-04 20:47:50 +0000 (10818)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 54638534-e774-4838-899a-737fafb4ef34 is TTL: 15```

**Ex 3. Full Logs**
```
### Post Change (Updated + 5 sec delay after receiving message)
# Consumer Dupe Check
[2024-06-04 20:47:50 +0000 (10290)] INFO : >>> MANNY <Consumer.01> Dupe Check: message.id: 997690ce-f1a5-4f2e-8844-3b8ae4e1ed9b, received_ts: 2024-06-04 20:47:45 +0000
  [2024-06-04 20:47:50 +0000 (10290)] INFO : [Aws::SQS::Client 200 0.066309 0 retries] get_queue_attributes(queue_url:"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_manny_v2_SendCurrency_Failures",attribute_names:["All"])
  [2024-06-04 20:47:50 +0000 (10290)] INFO : >>> MANNY <Duplicate Detector.01> BEGIN
    Msg_Data: {:id=>"997690ce-f1a5-4f2e-8844-3b8ae4e1ed9b", :queue=>"https://sqs.us-east-1.amazonaws.com/331510376354/tapinabox_manny_v2_SendCurrency_Failures", :visibility_timeout=>30, :received_timestamp=>2024-06-04 20:47:45.330152286 +0000}
  [2024-06-04 20:47:50 +0000 (10290)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 997690ce-f1a5-4f2e-8844-3b8ae4e1ed9b is TTL: 15
  [2024-06-04 20:47:50 +0000 (10290)] INFO : >>> MANNY <Chore Consumer.00>, Duplicate Found? false
  [2024-06-04 20:47:50 +0000 (10290)] INFO : >>> MANNY <Consumer.02> Dupe Check: No Duplicate Found

  # Create Unit of Work
  [2024-06-04 20:47:50 +0000 (10290)] INFO : >>> MANNY <Unit of Work.01> Created w ID:997690ce-f1a5-4f2e-8844-3b8ae4e1ed9b, Consumer , Timestamp: 2024-06-04 20:47:45 +0000
  [2024-06-04 20:47:50 +0000 (10290)] INFO : >>> MANNY <Throttled Consumer.01>, CREATED UoW: 997690ce-f1a5-4f2e-8844-3b8ae4e1ed9b, TS: 2024-06-04 20:47:45 +0000
    
    # Process Unit of Work
    [2024-06-04 20:47:50 +0000 (10818)] INFO : >>> MANNY <Worker.01> Processing Item: 997690ce-f1a5-4f2e-8844-3b8ae4e1ed9b, 2024-06-04 20:47:45 +0000
      
      # Worker Dupe Check
      [2024-06-04 20:47:50 +0000 (10818)] INFO : >>> MANNY <Duplicate Detector.01> BEGIN
        Msg_Data: {:id=>"54638534-e774-4838-899a-737fafb4ef34", :queue=>"NonManagedSendCurrencyJob", :visibility_timeout=>30, :received_timestamp=>2024-06-04 20:47:45.330152286 +0000}
      # IMPORTANT: Note the TTL is set to SQS' Visibility Timeout Config - 5 second delay
      [2024-06-04 20:47:50 +0000 (10818)] INFO : >>> MANNY <Duplicate Detector.02> New TTL for Msg ID 54638534-e774-4838-899a-737fafb4ef34 is TTL: 15
      [2024-06-04 20:47:50 +0000 (10818)] INFO : >>> MANNY <Chore Consumer.00>, Duplicate Found? false
    [2024-06-04 20:47:50 +0000 (10818)] INFO : >>> MANNY <Worker.03> Dupe Check: No Duplicate Found

# Errors out on TJS side (reward does not exist)
[2024-06-04 20:47:50 +0000 (10818)] ERROR : Failed to run job with error: Reward not found: 54638534-e774-4838-899a-737fafb4ef34
```

## Verification
* [ ] BQ
    * [ ] Verify increased retries coming in for day 4
    * [ ] Verify decreased retries coming in for days 1,2,3
    * [ ] Should also increase in rewrad success rate as we don't prematurely remove messages from the queue
* [ ] HC
    * [ ] Spotcheck some reward ids from BQ and verify the retry attempts
* [ ] NR
    * [ ] Verify Jobs-Currencies, Jobs-Conversion (Producers)
    * [ ] Verify SendCurrencyFailures (Consumers)
* [ ] Grafana
    * [ ] Verify SQS Dashboards no errors or unusual spikes
* [ ] AWS
    * [ ] Verify no increase in ApproximateMessageAge and 
    * [ ] Verify/Monitor NumberOfMessagesInQueue and Received

## References
* [REWARDS-417 Documention](https://docs.google.com/document/d/1rrHTIGv9KmEj2scG1kamTCxBeGoPc8niaVqQVzsXCQ8/edit)
* [REWARDS-417 BQ Data](https://docs.google.com/spreadsheets/d/1vZObLyYy3uojKhDsyBqGz82g2hDysILE2RWRWMfjI_0/edit?pli=1#gid=1637113445)
* [REWARDS-417 JIRA](https://jira.unity3d.com/browse/REWARDS-417)


Related PR: 
[REWARDS-458](https://jira.unity3d.com/browse/REWARDS-458): https://github.com/Tapjoy/tapjoyserver/pull/23374
