### PR TITLE
[NPE-719] Add PayloadHandler

### DIFF
--- a/lib/chore.rb
+++ b/lib/chore.rb
@@ -14,6 +14,7 @@ require 'chore/publisher'
 require 'chore/util'
 require 'chore/worker'
 require 'chore/publisher'
+require 'chore/payload_handler'
 
 # We have a number of things that can live here. I don't want to track
 ['queues/**','strategies/**'].each do |p|
@@ -42,7 +43,7 @@ module Chore #:nodoc:
     :max_attempts          => 1.0 / 0.0, # Infinity
     :dupe_on_cache_failure => false,
     :queue_polling_size    => 10,
-    :payload_handler       => Chore::Job,
+    :payload_handler       => Chore::PayloadHandler,
     :master_procline       => "chore-master-#{Chore::VERSION}",
     :worker_procline       => "chore-worker-#{Chore::VERSION}",
     :consumer_sleep_interval => 1

--- a/lib/chore/job.rb
+++ b/lib/chore/job.rb
@@ -7,7 +7,6 @@ module Chore
   # <tt>Chore::Job</tt> is the module which gives your job classes the methods they need to be published
   # and run within Chore. You cannot have a Job in Chore that does not include this module
   module Job
-    extend Util
 
     # An exception to represent a job choosing to forcibly reject a given instance of itself.
     # The reasoning behind rejecting the job and the message that spawned it are left to
@@ -26,18 +25,6 @@ module Chore
       @classes << base.name
       base.extend(ClassMethods)
       base.extend(Hooks)
-    end
-
-    def self.payload_class(message)
-      constantize(message['class'])
-    end
-
-    def self.decode(data)
-      Encoder::JsonEncoder.decode(data)
-    end
-
-    def self.payload(message)
-      message['args']
     end
 
     module ClassMethods
@@ -99,11 +86,6 @@ module Chore
         job.perform_async(*args)
       end
 
-      # Resque/Sidekiq compatible serialization. No reason to change what works
-      def job_hash(job_params)
-        {:class => self.to_s, :args => job_params}
-      end
-
       # The name of the configured queue, combined with an optional prefix
       #
       # @return [String]
@@ -142,15 +124,16 @@ module Chore
 
     # Use the current configured publisher to send this job into a queue.
     def perform_async(*args)
-      self.class.run_hooks_for(:before_publish,*args)
-      @chore_publisher ||= self.class.options[:publisher]
+      klass = self.class
+      klass.run_hooks_for(:before_publish,*args)
+      @chore_publisher ||= klass.options[:publisher]
 
-      publish_job_hash = self.class.job_hash(args)
-      Chore.run_hooks_for(:around_publish, self.class.prefixed_queue_name, publish_job_hash) do
-        @chore_publisher.publish(self.class.prefixed_queue_name,publish_job_hash)
+      publish_job_hash = Chore.config.payload_handler.job_hash(klass.to_s, args)
+      Chore.run_hooks_for(:around_publish, klass.prefixed_queue_name, publish_job_hash) do
+        @chore_publisher.publish(klass.prefixed_queue_name,publish_job_hash)
       end
 
-      self.class.run_hooks_for(:after_publish,*args)
+      klass.run_hooks_for(:after_publish,*args)
     end
 
   end #Job

--- a/lib/chore/payload_handler.rb
+++ b/lib/chore/payload_handler.rb
@@ -1,0 +1,24 @@
+module Chore
+  class PayloadHandler
+    extend Util
+
+    def self.payload_class(message)
+      constantize(message["class"])
+    end
+
+    # Takes UnitOfWork and return decoded message
+    def self.decode(item)
+      Encoder::JsonEncoder.decode(item.message)
+    end
+
+    def self.payload(message)
+      message["args"]
+    end
+
+    # Resque/Sidekiq compatible serialization. No reason to change what works
+    def self.job_hash(klass, job_params)
+      # JSON only recognizes string keys, so use strings as keys in our hash for consistency in encoding/decoding
+      {"class" => klass, "args" => job_params}
+    end
+  end
+end

--- a/lib/chore/worker.rb
+++ b/lib/chore/worker.rb
@@ -77,7 +77,7 @@ module Chore
       @work.each do |item|
         return if @stopping
         begin
-          item.decoded_message = options[:payload_handler].decode(item.message)
+          item.decoded_message = options[:payload_handler].decode(item)
           item.klass = options[:payload_handler].payload_class(item.decoded_message)
 
           next if duplicate_work?(item)

--- a/spec/chore/job_spec.rb
+++ b/spec/chore/job_spec.rb
@@ -66,15 +66,15 @@ describe Chore::Job do
     it 'should call an instance of the queue_options publisher' do
       args = [1,2,{:h => 'ash'}]
       TestJob.queue_options(:publisher => Chore::Publisher)
-      expect_any_instance_of(Chore::Publisher).to receive(:publish).with('test_queue',{:class => 'TestJob',:args => args}).and_return(true)
+      expect_any_instance_of(Chore::Publisher).to receive(:publish).with('test_queue',{"class" => 'TestJob',"args" => args}).and_return(true)
       TestJob.perform_async(*args)
     end
 
     it 'calls the around_publish hook with the correct parameters' do
       args = [1,2,{:h => 'ash'}]
-      expect(Chore).to receive(:run_hooks_for).with(:around_publish, 'test_queue', {:class => 'TestJob',:args => args}).and_call_original
+      expect(Chore).to receive(:run_hooks_for).with(:around_publish, 'test_queue', {"class" => 'TestJob',"args" => args}).and_call_original
       TestJob.queue_options(:publisher => Chore::Publisher)
-      expect_any_instance_of(Chore::Publisher).to receive(:publish).with('test_queue',{:class => 'TestJob',:args => args}).and_return(true)
+      expect_any_instance_of(Chore::Publisher).to receive(:publish).with('test_queue',{"class" => 'TestJob',"args" => args}).and_return(true)
       TestJob.perform_async(*args)
     end
   end

--- a/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/forked_worker_strategy_spec.rb
@@ -16,7 +16,7 @@ describe Chore::Strategy::ForkedWorkerStrategy do
       nil,
       'test',
       job_timeout,
-      Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])),
+      Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(TestJob, [1,2,"3"])),
       0,
       consumer
     )

--- a/spec/chore/strategies/worker/helpers/work_distributor_spec.rb
+++ b/spec/chore/strategies/worker/helpers/work_distributor_spec.rb
@@ -11,7 +11,7 @@ describe Chore::Strategy::WorkDistributor do
       SecureRandom.uuid,
       'test',
       60,
-      Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])),
+      Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(TestJob, [1,2,"3"])),
       0
     )
   end
@@ -89,7 +89,7 @@ describe Chore::Strategy::WorkDistributor do
         SecureRandom.uuid,
         'test',
         60,
-        Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])),
+        Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(TestJob, [1,2,"3"])),
         0
       )
       worker2 = Chore::Strategy::WorkerInfo.new(2)

--- a/spec/chore/strategies/worker/single_worker_strategy_spec.rb
+++ b/spec/chore/strategies/worker/single_worker_strategy_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Chore::Strategy::SingleWorkerStrategy do
   let(:manager) { double('Manager') }
   let(:job_timeout) { 60 }
-  let(:job) { Chore::UnitOfWork.new(SecureRandom.uuid, nil, 'test', job_timeout, Chore::Encoder::JsonEncoder.encode(TestJob.job_hash([1,2,"3"])), 0) }
+  let(:job) { Chore::UnitOfWork.new(SecureRandom.uuid, nil, 'test', job_timeout, Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(TestJob, [1,2,"3"])), 0) }
   subject       { described_class.new(manager) }
 
   describe '#stop!' do

--- a/spec/chore/worker_spec.rb
+++ b/spec/chore/worker_spec.rb
@@ -43,11 +43,11 @@ describe Chore::Worker do
 
   let(:consumer) { double('consumer', :complete => nil, :reject => nil) }
   let(:job_args) { [1,2,'3'] }
-  let(:job) { SimpleJob.job_hash(job_args) }
+  let(:job) { Chore::PayloadHandler.job_hash(SimpleJob, job_args) }
 
   it 'should use a default payload handler' do
     worker = Chore::Worker.new
-    expect(worker.options[:payload_handler]).to eq(Chore::Job)
+    expect(worker.options[:payload_handler]).to eq(Chore::PayloadHandler)
   end
 
   shared_examples_for "a worker" do
@@ -82,11 +82,11 @@ describe Chore::Worker do
       context 'when the value being deduped on is unique' do
         let(:job_args) { [rand,2,'3'] }
         let(:encoded_job) { Chore::Encoder::JsonEncoder.encode(job) }
-        let(:job) { SimpleDedupeJob.job_hash(job_args) }
+        let(:job) { Chore::PayloadHandler.job_hash(SimpleDedupeJob, job_args) }
         it 'should call complete for each unique value' do
           allow(consumer).to receive(:duplicate_message?).and_return(false)
           work = []
-          work << Chore::UnitOfWork.new(1, nil, 'dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(SimpleDedupeJob.job_hash([rand,2,'3'])), 0, consumer)
+          work << Chore::UnitOfWork.new(1, nil, 'dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(SimpleDedupeJob, [rand,2,'3'])), 0, consumer)
           expect(SimpleDedupeJob).to receive(:perform).exactly(1).times
           expect(consumer).to receive(:complete).exactly(1).times
           Chore::Worker.start(work, {:payload_handler => payload_handler})
@@ -96,9 +96,9 @@ describe Chore::Worker do
       context 'when the dedupe lambda does not take the same number of arguments as perform' do
         it 'should raise an error and not complete the job' do
           work = []
-          work << Chore::UnitOfWork.new(1, nil, 'invalid_dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(InvalidDedupeJob.job_hash([rand,2,'3'])), 0, consumer)
-          work << Chore::UnitOfWork.new(2, nil, 'invalid_dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(InvalidDedupeJob.job_hash([rand,2,'3'])), 0, consumer)
-          work << Chore::UnitOfWork.new(1, nil, 'invalid_dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(InvalidDedupeJob.job_hash([rand,2,'3'])), 0, consumer)
+          work << Chore::UnitOfWork.new(1, nil, 'invalid_dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(InvalidDedupeJob, [rand,2,'3'])), 0, consumer)
+          work << Chore::UnitOfWork.new(2, nil, 'invalid_dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(InvalidDedupeJob, [rand,2,'3'])), 0, consumer)
+          work << Chore::UnitOfWork.new(1, nil, 'invalid_dedupe_test', 60, Chore::Encoder::JsonEncoder.encode(Chore::PayloadHandler.job_hash(InvalidDedupeJob, [rand,2,'3'])), 0, consumer)
           expect(consumer).not_to receive(:complete)
           Chore::Worker.start(work, {:payload_handler => payload_handler})
         end
@@ -108,7 +108,7 @@ describe Chore::Worker do
 
   describe "with default payload handler" do
     let(:encoded_job) { Chore::Encoder::JsonEncoder.encode(job) }
-    let(:payload_handler) { Chore::Job }
+    let(:payload_handler) { Chore::PayloadHandler }
     let(:payload) {job_args}
     it_behaves_like "a worker"
   end


### PR DESCRIPTION
Adds `PayloadHandler` and makes it configurable so users can build custom payload handling for additional meta data or third party messaging consumption.

Chore is built upon the assumption that messages published to the queue will be handled by Chore. Even though Chore allows for configuration of `payload_handler`, it assumes a structure of the message that makes it difficult to do processing of messages that's not published by Chore (ie. third party streaming data). For instance, it assumes this `job_hash`:
```
{
  "class" => Klass,
  "args" => [arg1, arg2]
}
```
This makes it difficult to parse if the message does not correspond to this structure, for instance:
```
{
  "id" => "ID",
  "action" => "update",
  "params" => { "enabled" > true }
}
```
Chore determines the process to run by constantizing the class in the message which poses problems for messages published without this data. 

In order to facilitate the above, the method signature for decoding the message was updated to take the `UnitOfWork` with quite a bit of data. It also refactors code a bit to place message structure handling into `PayloadHandler` rather than `Job` to cleanly separate concerns. This way, a user has control over how messages should be constructed/deconstructed. The code still breaks if you don't follow the original `job_hash`, but it allows for great flexibility on the decoding of the message without reworking a ton of Chore internals. A custom payload handler may look like this.
```
module Chore
  class MyPayloadHandler < Chore::PayloadHandler
    # Override Chore's decoding to handle proper message handling for non-chore published messages
    def self.decode(item)
      klass = self.raw_json_queues[item.queue_name]
      if klass.present?
        args = Chore::Encoder::JsonEncoder.decode(item.message)
        # job_hash is defined on Chore::PayloadHandler and returns the expected Chore format for message
        return self.job_hash(klass, args) 
      else
        super
      end
    end

    def self.raw_json_queues
      # Class is stored as string for hot reloading in dev
      @raw_json_classes ||= {
        MyJob.prefixed_queue_name => "MyJob"
      }
    end
  end
end
```