### PR TITLE
NPE-785: Fix docker registry mirror not being used when building images

### DIFF
--- a/.github/workflows/unit_test-run.yaml
+++ b/.github/workflows/unit_test-run.yaml
@@ -52,6 +52,9 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         install: true
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
     # https://github.com/actions/checkout/tree/v4?tab=readme-ov-file#usage
     - name: Setup - Prepare dependency cache

--- a/.github/workflows/unit_test-run.yaml
+++ b/.github/workflows/unit_test-run.yaml
@@ -52,9 +52,9 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         install: true
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["mirror.gcr.io"]
+        buildkitd-config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
 
     # https://github.com/actions/checkout/tree/v4?tab=readme-ov-file#usage
     - name: Setup - Prepare dependency cache


### PR DESCRIPTION
https://jira.unity3d.com/browse/NPE-785

We're hitting rate limiting issues when building images on unity linux runners.  This is because the `docker/setup-buildx-action` workflow isn't configured to using the GCR mirror, which is what unity linux runners are set up to do by default (but doesn't apply when using this workflow).  This mirror is set up to avoid docker.io rate limiting.

This updates the configuration to force the GCR mirror to be used.

### Why
Full context here from slack:

> Possibilities:
> a) You pulled an image that was not on the cache and it had to fallback to dockerhub. Not all images are always available on the cache.
> b) Deamon is configured on the runner and it's always used when you run normal docker commands like docker build. When you use the buildx action, maybe it somehow doesn't inherit the configuration from there, or maybe it doesn't even use the deamon directly. However, the logs show that mirror is there. And if this hasn't happened before with buildx, this should likely happen more often.  ---> If this was the issue, you did the right fix.

And testing from slack:

> I tested this again today.  I attempted to pull up to 200 images on a unity-linux-runner with different configurations.  > The results:
> * No setup-buildx-action: Passed
> * setup-buildx-action with install: true : Failed
> * setup-buildx-action with install: true and buildkitd-config-inline overrides: Passed